### PR TITLE
Improve performance of texture loading and stitching by using STB

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinStitcher.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinStitcher.java
@@ -1,0 +1,52 @@
+package me.eigenraven.lwjgl3ify.mixins.game;
+
+import me.eigenraven.lwjgl3ify.textures.StbStitcher;
+import net.minecraft.client.renderer.texture.Stitcher;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.*;
+
+@Mixin(Stitcher.class)
+public abstract class MixinStitcher {
+    @Shadow
+    @Final
+    private Set setStitchHolders = new HashSet(256);
+    @Shadow
+    private int currentWidth;
+    @Shadow
+    private int currentHeight;
+
+    /**
+     * @author SuperCoder79
+     * @reason Use improved STB stitcher instead of the vanilla implementation, for performance
+     */
+    @Overwrite
+    public void doStitch() {
+        Stitcher.Holder[] aholder = (Stitcher.Holder[])this.setStitchHolders.toArray(new Stitcher.Holder[this.setStitchHolders.size()]);
+        Arrays.sort(aholder);
+
+        int size = StbStitcher.packRects(aholder);
+        this.currentWidth = size;
+        this.currentHeight = size;
+    }
+
+    /**
+     * @author SuperCoder79
+     * @reason We setup the image ourselves in the StbStitcher, so we only need to return the the atlas sprites now
+     * @return A list of all the atlas sprites
+     */
+    @Overwrite
+    public List getStichSlots() {
+        ArrayList<TextureAtlasSprite> arraylist = new ArrayList<>();
+
+        for (Stitcher.Holder holder : (Set<Stitcher.Holder>)this.setStitchHolders) {
+            arraylist.add(holder.getAtlasSprite());
+        }
+
+        return arraylist;
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinStitcher.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinStitcher.java
@@ -1,5 +1,6 @@
 package me.eigenraven.lwjgl3ify.mixins.game;
 
+import java.util.*;
 import me.eigenraven.lwjgl3ify.textures.StbStitcher;
 import net.minecraft.client.renderer.texture.Stitcher;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -8,15 +9,15 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.util.*;
-
 @Mixin(Stitcher.class)
 public abstract class MixinStitcher {
     @Shadow
     @Final
     private Set setStitchHolders = new HashSet(256);
+
     @Shadow
     private int currentWidth;
+
     @Shadow
     private int currentHeight;
 
@@ -26,7 +27,8 @@ public abstract class MixinStitcher {
      */
     @Overwrite
     public void doStitch() {
-        Stitcher.Holder[] aholder = (Stitcher.Holder[])this.setStitchHolders.toArray(new Stitcher.Holder[this.setStitchHolders.size()]);
+        Stitcher.Holder[] aholder =
+                (Stitcher.Holder[]) this.setStitchHolders.toArray(new Stitcher.Holder[this.setStitchHolders.size()]);
         Arrays.sort(aholder);
 
         int size = StbStitcher.packRects(aholder);
@@ -43,7 +45,7 @@ public abstract class MixinStitcher {
     public List getStichSlots() {
         ArrayList<TextureAtlasSprite> arraylist = new ArrayList<>();
 
-        for (Stitcher.Holder holder : (Set<Stitcher.Holder>)this.setStitchHolders) {
+        for (Stitcher.Holder holder : (Set<Stitcher.Holder>) this.setStitchHolders) {
             arraylist.add(holder.getAtlasSprite());
         }
 

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureAtlasSprite.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureAtlasSprite.java
@@ -1,5 +1,6 @@
 package me.eigenraven.lwjgl3ify.mixins.game;
 
+import java.awt.image.BufferedImage;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.data.AnimationMetadataSection;
 import org.spongepowered.asm.mixin.Mixin;
@@ -7,12 +8,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.awt.image.BufferedImage;
-
 @Mixin(TextureAtlasSprite.class)
 public class MixinTextureAtlasSprite {
     @Inject(method = "loadSprite", at = @At("TAIL"))
-    void cleanupAfterLoadSprite(BufferedImage[] frames, AnimationMetadataSection aniData, boolean anisotropicFiltering, CallbackInfo info) {
+    void cleanupAfterLoadSprite(
+            BufferedImage[] frames, AnimationMetadataSection aniData, boolean anisotropicFiltering, CallbackInfo info) {
         for (BufferedImage img : frames) {
             // Close any NativeBackedImage instances
             if (img instanceof AutoCloseable) {

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureAtlasSprite.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureAtlasSprite.java
@@ -1,0 +1,27 @@
+package me.eigenraven.lwjgl3ify.mixins.game;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.data.AnimationMetadataSection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.awt.image.BufferedImage;
+
+@Mixin(TextureAtlasSprite.class)
+public class MixinTextureAtlasSprite {
+    @Inject(method = "loadSprite", at = @At("TAIL"))
+    void cleanupAfterLoadSprite(BufferedImage[] frames, AnimationMetadataSection aniData, boolean anisotropicFiltering, CallbackInfo info) {
+        for (BufferedImage img : frames) {
+            // Close any NativeBackedImage instances
+            if (img instanceof AutoCloseable) {
+                try {
+                    ((AutoCloseable) img).close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureMap.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureMap.java
@@ -1,5 +1,8 @@
 package me.eigenraven.lwjgl3ify.mixins.game;
 
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
 import me.eigenraven.lwjgl3ify.textures.NativeBackedImage;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -7,13 +10,15 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.io.InputStream;
-
 @Mixin(TextureMap.class)
 public abstract class MixinTextureMap extends AbstractTexture {
-    @Redirect(method = "loadTextureAtlas", at = @At(value = "INVOKE", target = "Ljavax/imageio/ImageIO;read(Ljava/io/InputStream;)Ljava/awt/image/BufferedImage;", remap = false))
+    @Redirect(
+            method = "loadTextureAtlas",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target = "Ljavax/imageio/ImageIO;read(Ljava/io/InputStream;)Ljava/awt/image/BufferedImage;",
+                            remap = false))
     private BufferedImage redirectImageRead(InputStream stream) {
         try {
             return NativeBackedImage.make(stream);

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureMap.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/game/MixinTextureMap.java
@@ -1,0 +1,24 @@
+package me.eigenraven.lwjgl3ify.mixins.game;
+
+import me.eigenraven.lwjgl3ify.textures.NativeBackedImage;
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.TextureMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Mixin(TextureMap.class)
+public abstract class MixinTextureMap extends AbstractTexture {
+    @Redirect(method = "loadTextureAtlas", at = @At(value = "INVOKE", target = "Ljavax/imageio/ImageIO;read(Ljava/io/InputStream;)Ljava/awt/image/BufferedImage;", remap = false))
+    private BufferedImage redirectImageRead(InputStream stream) {
+        try {
+            return NativeBackedImage.make(stream);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/FastByteChannel.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/FastByteChannel.java
@@ -10,59 +10,57 @@ import java.nio.channels.spi.AbstractInterruptibleChannel;
 // ReadableByteChannel impl without locking.
 // In cases where the channel can never be accessed concurrently, this is a significant performance improvement.
 public class FastByteChannel extends AbstractInterruptibleChannel implements ReadableByteChannel {
-        private final InputStream in;
-        private static final int TRANSFER_SIZE = 8192;
-        private byte[] buf = new byte[0];
+    private final InputStream in;
+    private static final int TRANSFER_SIZE = 8192;
+    private byte[] buf = new byte[0];
 
-        public FastByteChannel(InputStream in) {
-            this.in = in;
-        }
-
-        @Override
-        public int read(ByteBuffer dst) throws IOException {
-            if (!isOpen()) {
-                throw new ClosedChannelException();
-            }
-
-            int len = dst.remaining();
-            int totalRead = 0;
-            int bytesRead = 0;
-            while (totalRead < len) {
-                int bytesToRead = Math.min((len - totalRead),
-                                           TRANSFER_SIZE);
-                if (buf.length < bytesToRead) {
-                    buf = new byte[bytesToRead];
-                }
-
-                if ((totalRead > 0) && !(in.available() > 0)) {
-                    break; // block at most once
-                }
-
-                try {
-                    begin();
-                    bytesRead = in.read(buf, 0, bytesToRead);
-                } finally {
-                    end(bytesRead > 0);
-                }
-
-                if (bytesRead < 0) {
-                    break;
-                }
-                else {
-                    totalRead += bytesRead;
-                }
-                dst.put(buf, 0, bytesRead);
-            }
-
-            if ((bytesRead < 0) && (totalRead == 0)) {
-                return -1;
-            }
-
-            return totalRead;
-        }
-
-        @Override
-        protected void implCloseChannel() throws IOException {
-            in.close();
-        }
+    public FastByteChannel(InputStream in) {
+        this.in = in;
     }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        if (!isOpen()) {
+            throw new ClosedChannelException();
+        }
+
+        int len = dst.remaining();
+        int totalRead = 0;
+        int bytesRead = 0;
+        while (totalRead < len) {
+            int bytesToRead = Math.min((len - totalRead), TRANSFER_SIZE);
+            if (buf.length < bytesToRead) {
+                buf = new byte[bytesToRead];
+            }
+
+            if ((totalRead > 0) && !(in.available() > 0)) {
+                break; // block at most once
+            }
+
+            try {
+                begin();
+                bytesRead = in.read(buf, 0, bytesToRead);
+            } finally {
+                end(bytesRead > 0);
+            }
+
+            if (bytesRead < 0) {
+                break;
+            } else {
+                totalRead += bytesRead;
+            }
+            dst.put(buf, 0, bytesRead);
+        }
+
+        if ((bytesRead < 0) && (totalRead == 0)) {
+            return -1;
+        }
+
+        return totalRead;
+    }
+
+    @Override
+    protected void implCloseChannel() throws IOException {
+        in.close();
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/FastByteChannel.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/FastByteChannel.java
@@ -1,0 +1,68 @@
+package me.eigenraven.lwjgl3ify.textures;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.spi.AbstractInterruptibleChannel;
+
+// ReadableByteChannel impl without locking.
+// In cases where the channel can never be accessed concurrently, this is a significant performance improvement.
+public class FastByteChannel extends AbstractInterruptibleChannel implements ReadableByteChannel {
+        private final InputStream in;
+        private static final int TRANSFER_SIZE = 8192;
+        private byte[] buf = new byte[0];
+
+        public FastByteChannel(InputStream in) {
+            this.in = in;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            if (!isOpen()) {
+                throw new ClosedChannelException();
+            }
+
+            int len = dst.remaining();
+            int totalRead = 0;
+            int bytesRead = 0;
+            while (totalRead < len) {
+                int bytesToRead = Math.min((len - totalRead),
+                                           TRANSFER_SIZE);
+                if (buf.length < bytesToRead) {
+                    buf = new byte[bytesToRead];
+                }
+
+                if ((totalRead > 0) && !(in.available() > 0)) {
+                    break; // block at most once
+                }
+
+                try {
+                    begin();
+                    bytesRead = in.read(buf, 0, bytesToRead);
+                } finally {
+                    end(bytesRead > 0);
+                }
+
+                if (bytesRead < 0) {
+                    break;
+                }
+                else {
+                    totalRead += bytesRead;
+                }
+                dst.put(buf, 0, bytesRead);
+            }
+
+            if ((bytesRead < 0) && (totalRead == 0)) {
+                return -1;
+            }
+
+            return totalRead;
+        }
+
+        @Override
+        protected void implCloseChannel() throws IOException {
+            in.close();
+        }
+    }

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/NativeBackedImage.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/NativeBackedImage.java
@@ -1,10 +1,5 @@
 package me.eigenraven.lwjgl3ify.textures;
 
-import org.apache.commons.io.IOUtils;
-import org.lwjgl.stb.STBImage;
-import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
-
 import java.awt.image.BufferedImage;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -13,6 +8,10 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import org.apache.commons.io.IOUtils;
+import org.lwjgl.stb.STBImage;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 
 public class NativeBackedImage extends BufferedImage implements AutoCloseable {
     private final int width;
@@ -90,7 +89,8 @@ public class NativeBackedImage extends BufferedImage implements AutoCloseable {
 
     private void checkBounds(int x, int z) {
         if (x < 0 || x >= this.width || z < 0 || z >= this.height) {
-            throw new IllegalStateException("Out of bounds: " + x + ", " + z + " (width: " + this.width + ", height: " + this.height + ")");
+            throw new IllegalStateException(
+                    "Out of bounds: " + x + ", " + z + " (width: " + this.width + ", height: " + this.height + ")");
         }
     }
 
@@ -114,9 +114,7 @@ public class NativeBackedImage extends BufferedImage implements AutoCloseable {
                     throw new IOException("Could not load image: " + STBImage.stbi_failure_reason());
                 }
 
-                return new NativeBackedImage(
-                    width.get(0), height.get(0), MemoryUtil.memAddress(buf)
-                );
+                return new NativeBackedImage(width.get(0), height.get(0), MemoryUtil.memAddress(buf));
             }
 
         } finally {
@@ -129,11 +127,10 @@ public class NativeBackedImage extends BufferedImage implements AutoCloseable {
     private static ByteBuffer readResource(InputStream inputStream) throws IOException {
         ByteBuffer byteBuffer;
         if (inputStream instanceof FileInputStream) {
-            FileChannel fileChannel = ((FileInputStream)inputStream).getChannel();
-            byteBuffer = MemoryUtil.memAlloc((int)fileChannel.size() + 1);
+            FileChannel fileChannel = ((FileInputStream) inputStream).getChannel();
+            byteBuffer = MemoryUtil.memAlloc((int) fileChannel.size() + 1);
 
-            while(fileChannel.read(byteBuffer) != -1) {
-            }
+            while (fileChannel.read(byteBuffer) != -1) {}
         } else {
             int sizeGuess = 4096;
             try {
@@ -144,7 +141,7 @@ public class NativeBackedImage extends BufferedImage implements AutoCloseable {
             byteBuffer = MemoryUtil.memAlloc(sizeGuess * 2);
             ReadableByteChannel readableByteChannel = new FastByteChannel(inputStream);
 
-            while(readableByteChannel.read(byteBuffer) != -1) {
+            while (readableByteChannel.read(byteBuffer) != -1) {
                 // If we've filled the buffer, make it twice as large and re-parse
                 if (byteBuffer.remaining() == 0) {
                     byteBuffer = MemoryUtil.memRealloc(byteBuffer, byteBuffer.capacity() * 2);

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/NativeBackedImage.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/NativeBackedImage.java
@@ -1,0 +1,147 @@
+package me.eigenraven.lwjgl3ify.textures;
+
+import org.apache.commons.io.IOUtils;
+import org.lwjgl.stb.STBImage;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+
+import java.awt.image.BufferedImage;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+
+public class NativeBackedImage extends BufferedImage implements AutoCloseable {
+    private final int width;
+    private final int height;
+    private final long pointer;
+    private final int sizeBytes;
+
+    private NativeBackedImage(int width, int height, long pointer) {
+        super(width, height, TYPE_INT_ARGB);
+        this.width = width;
+        this.height = height;
+        this.pointer = pointer;
+
+        // 4 channels: RGBA
+        this.sizeBytes = width * height * 4;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    @Override
+    public int[] getRGB(int startX, int startY, int w, int h, int[] rgbArray, int offset, int scansize) {
+
+        // Inverse itr for cache coherency
+        for (int z = startY; z < h; z++) {
+            for (int x = startX; x < w; x++) {
+                int color = MemoryUtil.memGetInt(this.pointer + ((x + z * width) * 4));
+                // ABGR -> ARGB
+                int a = (color >> 24) & 0xFF;
+                int b = (color >> 16) & 0xFF;
+                int g = (color >> 8) & 0xFF;
+                int r = (color >> 0) & 0xFF;
+
+                int finalColor = (a << 24) | (r << 16) | (g << 8) | b;
+
+                rgbArray[x + (z * width)] = finalColor;
+            }
+        }
+
+        return rgbArray;
+    }
+
+    @Override
+    public int getRGB(int x, int z) {
+        checkBounds(x, z);
+
+        return MemoryUtil.memGetInt(this.pointer + ((x + z * width) * 4));
+    }
+
+    @Override
+    public void setRGB(int x, int z, int rgb) {
+        checkBounds(x, z);
+
+        MemoryUtil.memPutInt(this.pointer + ((x + z * width) * 4), rgb);
+    }
+
+    @Override
+    public BufferedImage getSubimage(int x, int y, int w, int h) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void close() throws Exception {
+        STBImage.nstbi_image_free(this.pointer);
+    }
+
+    private void checkBounds(int x, int z) {
+        if (x < 0 || x >= this.width || z < 0 || z >= this.height) {
+            throw new IllegalStateException("Out of bounds: " + x + ", " + z + " (width: " + this.width + ", height: " + this.height + ")");
+        }
+    }
+
+    // Parsing
+
+    public static NativeBackedImage make(InputStream stream) throws IOException {
+        ByteBuffer imgBuf = null;
+
+        try {
+            imgBuf = readResource(stream);
+            imgBuf.rewind();
+
+            try (MemoryStack memoryStack = MemoryStack.stackPush()) {
+                IntBuffer width = memoryStack.mallocInt(1);
+                IntBuffer height = memoryStack.mallocInt(1);
+                IntBuffer channels = memoryStack.mallocInt(1);
+
+                // 4 channels: RGBA
+                ByteBuffer buf = STBImage.stbi_load_from_memory(imgBuf, width, height, channels, 4);
+                if (buf == null) {
+                    throw new IOException("Could not load image: " + STBImage.stbi_failure_reason());
+                }
+
+                return new NativeBackedImage(
+                    width.get(0), height.get(0), MemoryUtil.memAddress(buf)
+                );
+            }
+
+        } finally {
+            // free
+            MemoryUtil.memFree(imgBuf);
+            IOUtils.closeQuietly(stream);
+        }
+    }
+
+    private static ByteBuffer readResource(InputStream inputStream) throws IOException {
+        ByteBuffer byteBuffer;
+        if (inputStream instanceof FileInputStream) {
+            FileChannel fileChannel = ((FileInputStream)inputStream).getChannel();
+            byteBuffer = MemoryUtil.memAlloc((int)fileChannel.size() + 1);
+
+            while(fileChannel.read(byteBuffer) != -1) {
+            }
+        } else {
+            byteBuffer = MemoryUtil.memAlloc(8192);
+            ReadableByteChannel readableByteChannel = new FastByteChannel(inputStream);
+
+            while(readableByteChannel.read(byteBuffer) != -1) {
+                // If we've filled the buffer, make it twice as large and re-parse
+                if (byteBuffer.remaining() == 0) {
+                    byteBuffer = MemoryUtil.memRealloc(byteBuffer, byteBuffer.capacity() * 2);
+                }
+            }
+        }
+
+        return byteBuffer;
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/StbStitcher.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/StbStitcher.java
@@ -19,8 +19,8 @@ public class StbStitcher {
 
         // Allocate memory for the rectangles and the context
         try (
-            STBRPRect.Buffer rectBuf = STBRPRect.calloc(holderSize);
-            STBRPContext ctx = STBRPContext.calloc();
+            STBRPRect.Buffer rectBuf = STBRPRect.malloc(holderSize);
+            STBRPContext ctx = STBRPContext.malloc();
             ) {
 
             // Initialize the rectangles that we'll be using in the calculation
@@ -44,7 +44,7 @@ public class StbStitcher {
             // TODO: if sqSize < (size * size) / 2, then we can use size / 2 for the height to save VRAM
 
             // Internal node structure needed for STB
-            try (STBRPNode.Buffer nodes = STBRPNode.calloc(size + 1)) {
+            try (STBRPNode.Buffer nodes = STBRPNode.malloc(size + 1)) {
                 // Initialize the rect packer
                 STBRectPack.stbrp_init_target(ctx, size, size, nodes);
 

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/StbStitcher.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/StbStitcher.java
@@ -18,10 +18,8 @@ public class StbStitcher {
         int holderSize = holders.length;
 
         // Allocate memory for the rectangles and the context
-        try (
-            STBRPRect.Buffer rectBuf = STBRPRect.malloc(holderSize);
-            STBRPContext ctx = STBRPContext.malloc();
-            ) {
+        try (STBRPRect.Buffer rectBuf = STBRPRect.malloc(holderSize);
+                STBRPContext ctx = STBRPContext.malloc(); ) {
 
             // Initialize the rectangles that we'll be using in the calculation
             // While that's happening, sum up the area needed to fit all of the images
@@ -59,7 +57,10 @@ public class StbStitcher {
 
                     // Ensure that everything is properly packed!
                     if (!rect.was_packed()) {
-                        throw new StitcherException(holder, "Could not fit " + holder.getAtlasSprite().getIconName() + " into " + size + "x" + size + " atlas!");
+                        throw new StitcherException(
+                                holder,
+                                "Could not fit " + holder.getAtlasSprite().getIconName() + " into " + size + "x" + size
+                                        + " atlas!");
                     }
 
                     bar.step(holder.getAtlasSprite().getIconName());

--- a/src/main/java/me/eigenraven/lwjgl3ify/textures/StbStitcher.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/textures/StbStitcher.java
@@ -1,0 +1,79 @@
+package me.eigenraven.lwjgl3ify.textures;
+
+import cpw.mods.fml.common.ProgressManager;
+import me.eigenraven.lwjgl3ify.api.Lwjgl3Aware;
+import net.minecraft.client.renderer.StitcherException;
+import net.minecraft.client.renderer.texture.Stitcher;
+import net.minecraft.util.MathHelper;
+import org.lwjgl.stb.STBRPContext;
+import org.lwjgl.stb.STBRPNode;
+import org.lwjgl.stb.STBRPRect;
+import org.lwjgl.stb.STBRectPack;
+
+@Lwjgl3Aware
+public class StbStitcher {
+    // Returns size
+    public static int packRects(Stitcher.Holder[] holders) {
+        ProgressManager.ProgressBar bar = ProgressManager.push("Stitch setup", holders.length);
+        int holderSize = holders.length;
+
+        // Allocate memory for the rectangles and the context
+        try (
+            STBRPRect.Buffer rectBuf = STBRPRect.calloc(holderSize);
+            STBRPContext ctx = STBRPContext.calloc();
+            ) {
+
+            // Initialize the rectangles that we'll be using in the calculation
+            // While that's happening, sum up the area needed to fit all of the images
+            int sqSize = 0;
+            for (int j = 0; j < holderSize; ++j) {
+                Stitcher.Holder holder = holders[j];
+                bar.step(holder.getAtlasSprite().getIconName());
+
+                int width = holder.getWidth();
+                int height = holder.getHeight();
+
+                // The ID here is just the array index, for easy lookup later
+                rectBuf.get(j).set(j, width, height, 0, 0, false);
+
+                sqSize += (width * height);
+            }
+
+            int size = MathHelper.roundUpToPowerOfTwo((int) Math.sqrt(sqSize));
+
+            // TODO: if sqSize < (size * size) / 2, then we can use size / 2 for the height to save VRAM
+
+            // Internal node structure needed for STB
+            try (STBRPNode.Buffer nodes = STBRPNode.calloc(size + 1)) {
+                // Initialize the rect packer
+                STBRectPack.stbrp_init_target(ctx, size, size, nodes);
+
+                // Perform rectangle packing
+                STBRectPack.stbrp_pack_rects(ctx, rectBuf);
+
+                ProgressManager.pop(bar);
+                bar = ProgressManager.push("Stitch retrieve", holders.length);
+
+                for (STBRPRect rect : rectBuf) {
+                    Stitcher.Holder holder = holders[rect.id()];
+
+                    // Ensure that everything is properly packed!
+                    if (!rect.was_packed()) {
+                        throw new StitcherException(holder, "Could not fit " + holder.getAtlasSprite().getIconName() + " into " + size + "x" + size + " atlas!");
+                    }
+
+                    bar.step(holder.getAtlasSprite().getIconName());
+
+                    // Initialize the sprite now with the position and size that we've calculated so far
+
+                    // texture should not be rotated, so use false
+                    holder.getAtlasSprite().initSprite(size, size, rect.x(), rect.y(), false);
+                }
+
+                ProgressManager.pop(bar);
+
+                return size;
+            }
+        }
+    }
+}

--- a/src/main/resources/mixins.lwjgl3ify.json
+++ b/src/main/resources/mixins.lwjgl3ify.json
@@ -12,6 +12,9 @@
     "fml.ObjectHolderRef",
     "fml.ObjectHolderRegistry",
     "fml.ItemStackHolderRef",
-    "fml.JarDiscoverer"
+    "fml.JarDiscoverer",
+    "game.MixinTextureMap",
+    "game.MixinStitcher",
+    "game.MixinTextureAtlasSprite"
   ]
 }

--- a/src/main/resources/mixins.lwjgl3ify.json
+++ b/src/main/resources/mixins.lwjgl3ify.json
@@ -12,7 +12,9 @@
     "fml.ObjectHolderRef",
     "fml.ObjectHolderRegistry",
     "fml.ItemStackHolderRef",
-    "fml.JarDiscoverer",
+    "fml.JarDiscoverer"
+  ],
+  "client": [
     "game.MixinTextureMap",
     "game.MixinStitcher",
     "game.MixinTextureAtlasSprite"


### PR DESCRIPTION
This PR improves the performance of Minecraft's texture parsing and stitching by replacing various algorithms with LWJGL3's STB bindings. The changes include using stb_image to parse images at a rate significantly faster than Java's ImageIO, and using stb_rect_pack to stitch images significantly faster.

### Prior art
This PR builds mostly off of the `NativeImage` construct in modern Minecraft versions, adapting it to work with 1.7.10 by extending BufferedImage. This allows easy compatibility with the existing code, as the implementation details of the image storage can be hidden.

### Performance improvements
When reloading resource packs (by adding uu-tex, gtnh 32x, and gtnh faithful), the time it takes for the game to un-freeze goes from 8.3 seconds without this patch to 4.8 seconds with this patch. That's roughly a 70% improvement!

### Future work 
* Even with this patch, there are multiple inefficiencies- mipmap generation and zip file system reading are a couple. When textures are oversized, the algorithm needs to extend the size of the buffer and re-try parsing- which means for larger textures the file system has to retrieve the same file's data up to 4-5 times.
* Other mods also rely on ImageIO and bufferedimage, such as IC2's `BlockStitchedTexture`. These instances could also be removed to improve performance.