### PR TITLE
HACK: Temporary workaround for glColor3ub crash on macOS

### DIFF
--- a/src/generated/java/org/lwjglx/opengl/GL11.java
+++ b/src/generated/java/org/lwjglx/opengl/GL11.java
@@ -625,8 +625,13 @@ public class GL11 {
         org.lwjgl.opengl.GL11.glColor3f(red, green, blue);
     }
 
+    private static final int UNSIGNED_BYTE_TO_INT_RATIO = Integer.MAX_VALUE / 255;
+
     public static void glColor3ub(byte red, byte green, byte blue) {
-        org.lwjgl.opengl.GL11.glColor3ub(red, green, blue);
+        org.lwjgl.opengl.GL11.glColor3i(
+                (red & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
+                (green & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
+                (blue & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO);
     }
 
     public static void glColor4b(byte red, byte green, byte blue, byte alpha) {


### PR DESCRIPTION
glColor3ub is causing SEGFAULT on negative values on macOS, use glColor3i instead.

See https://github.com/LWJGL/lwjgl3/issues/858

This call is rarely used so performance impact should be minimal.