### PR TITLE
Revert the glColor3ub hack

### DIFF
--- a/src/generated/java/org/lwjglx/opengl/GL11.java
+++ b/src/generated/java/org/lwjglx/opengl/GL11.java
@@ -625,13 +625,8 @@ public class GL11 {
         org.lwjgl.opengl.GL11.glColor3f(red, green, blue);
     }
 
-    private static final int UNSIGNED_BYTE_TO_INT_RATIO = Integer.MAX_VALUE / 255;
-
     public static void glColor3ub(byte red, byte green, byte blue) {
-        org.lwjgl.opengl.GL11.glColor3i(
-                (red & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
-                (green & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
-                (blue & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO);
+        org.lwjgl.opengl.GL11.glColor3ub(red, green, blue);
     }
 
     public static void glColor4b(byte red, byte green, byte blue, byte alpha) {
@@ -647,11 +642,7 @@ public class GL11 {
     }
 
     public static void glColor4ub(byte red, byte green, byte blue, byte alpha) {
-        org.lwjgl.opengl.GL11.glColor4i(
-                (red & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
-                (green & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
-                (blue & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO,
-                (alpha & 0xff) * UNSIGNED_BYTE_TO_INT_RATIO);
+        org.lwjgl.opengl.GL11.glColor4ub(red, green, blue, alpha);
     }
 
     public static void glColorMask(boolean red, boolean green, boolean blue, boolean alpha) {


### PR DESCRIPTION
It's not needed for LWJGL version 3.3.2-20230304.162250-10 and up.