### PR TITLE
Add multibyte char event handling by duplicating key events when multiple chars happen after a single keypress

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
@@ -49,6 +49,7 @@ public class Config {
     public static boolean DEBUG_PRINT_KEY_EVENTS = false;
     public static boolean DEBUG_PRINT_MOUSE_EVENTS = false;
 
+    public static boolean MBE_ENABLED = true;
     public static boolean IME_ENABLED = false;
     public static boolean IME_F12_TOGGLE = false;
     public static boolean IME_SYS_TOGGLE = false;
@@ -136,6 +137,8 @@ public class Config {
                 DEBUG_PRINT_MOUSE_EVENTS,
                 "Print mouse-related events to the log");
 
+        MBE_ENABLED = config
+                .getBoolean("handleMultibyteInput", CATEGORY_CORE, MBE_ENABLED, "Enables multibyte character input.");
         IME_ENABLED = config.getBoolean("enabled", CATEGORY_IME, IME_ENABLED, "Enables IME support for CJK input.");
         IME_F12_TOGGLE = config
                 .getBoolean("f12Toggle", CATEGORY_IME, IME_F12_TOGGLE, "Enables switching IME mode by pressing F12.");

--- a/src/main/java/org/lwjglx/input/EventQueue.java
+++ b/src/main/java/org/lwjglx/input/EventQueue.java
@@ -6,7 +6,7 @@ package org.lwjglx.input;
  */
 class EventQueue {
 
-    private int maxEvents = 32;
+    private final int maxEvents;
     private int eventCount = 0;
     private int readEventPos = 0;
     private int writeEventPos = 1;
@@ -42,7 +42,7 @@ class EventQueue {
 
     /**
      * Increment the event queue
-     * 
+     *
      * @return - true if there is an event available
      */
     synchronized boolean next() {
@@ -65,6 +65,10 @@ class EventQueue {
 
     int getCurrentPos() {
         return readEventPos;
+    }
+
+    int getLastWrittenPos() {
+        return (writeEventPos + maxEvents - 1) % maxEvents;
     }
 
     int getNextPos() {


### PR DESCRIPTION
This should provide some very basic IME support for multibyte inputs with much less hacks than the other method. I'm keeping the other method in as it can provide a better experience with AWT integration.