### PR TITLE
[WIP] libffi native IME interface

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/UnsafeHacks.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/UnsafeHacks.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @SuppressWarnings({ "restriction", "sunapi" })
 public class UnsafeHacks {
 
-    private static final sun.misc.Unsafe UNSAFE;
+    public static final sun.misc.Unsafe UNSAFE;
 
     static {
         try {

--- a/src/main/java/me/eigenraven/lwjgl3ify/ime/IImeNativeInterface.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/ime/IImeNativeInterface.java
@@ -1,0 +1,8 @@
+package me.eigenraven.lwjgl3ify.ime;
+
+import java.io.Closeable;
+
+public interface IImeNativeInterface extends Closeable {
+
+    boolean isCompositionEnabled();
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/ime/ImeNativeInterface.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/ime/ImeNativeInterface.java
@@ -1,0 +1,24 @@
+package me.eigenraven.lwjgl3ify.ime;
+
+import me.eigenraven.lwjgl3ify.api.Lwjgl3Aware;
+import me.eigenraven.lwjgl3ify.ime.impl.DummyIme;
+import me.eigenraven.lwjgl3ify.ime.impl.LinuxIme;
+
+import org.lwjgl.system.Platform;
+
+@Lwjgl3Aware
+public class ImeNativeInterface {
+
+    public static IImeNativeInterface make() {
+        try {
+            return switch (Platform.get()) {
+                case LINUX -> new LinuxIme();
+                default -> new DummyIme();
+            };
+        } catch (Exception e) {
+            System.err.println("Could not construct a native platform IME wrapper: " + e);
+            e.printStackTrace();
+            return new DummyIme();
+        }
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/ime/impl/DummyIme.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/ime/impl/DummyIme.java
@@ -1,0 +1,20 @@
+package me.eigenraven.lwjgl3ify.ime.impl;
+
+import java.io.IOException;
+
+import me.eigenraven.lwjgl3ify.ime.IImeNativeInterface;
+
+public class DummyIme implements IImeNativeInterface {
+
+    public DummyIme() {
+        System.err.println("Creating a dummy IME implementation, CJK input might not work as intended");
+    }
+
+    @Override
+    public void close() throws IOException {}
+
+    @Override
+    public boolean isCompositionEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/ime/impl/LinuxIme.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/ime/impl/LinuxIme.java
@@ -1,0 +1,161 @@
+package me.eigenraven.lwjgl3ify.ime.impl;
+
+import static org.lwjgl.system.MemoryUtil.*;
+import static org.lwjgl.system.libffi.LibFFI.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import me.eigenraven.lwjgl3ify.UnsafeHacks;
+import me.eigenraven.lwjgl3ify.api.Lwjgl3Aware;
+import me.eigenraven.lwjgl3ify.ime.IImeNativeInterface;
+
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWNativeX11;
+import org.lwjgl.system.APIUtil;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.Pointer;
+import org.lwjgl.system.SharedLibrary;
+import org.lwjgl.system.libffi.FFICIF;
+import org.lwjgl.system.linux.X11;
+import org.lwjglx.opengl.Display;
+
+import sun.misc.Unsafe;
+
+@Lwjgl3Aware
+public class LinuxIme implements IImeNativeInterface {
+
+    private static final Unsafe UNSAFE = UnsafeHacks.UNSAFE;
+    private static final int POINTER_SIZE = Pointer.POINTER_SIZE;
+
+    private final long xicPtr;
+
+    private final long XVaCreateNestedList_PFN, XGetICValues_PFN;
+    private final FFICIF XVaCreateNestedList_CIF, XGetICValues_CIF;
+    private static final ByteBuffer XNPreeditState = memASCII("preeditState");
+    private static final ByteBuffer XNPreeditAttributes = memASCII("preeditAttributes");
+    private static final long XIMPreeditUnKnown = 0;
+    private static final long XIMPreeditEnable = 1;
+    private static final long XIMPreeditDisable = 2;
+
+    private static long peekPointer(long address) {
+        return switch (POINTER_SIZE) {
+            case 4 -> UNSAFE.getInt(address);
+            case 8 -> UNSAFE.getLong(address);
+            default -> throw new UnsupportedOperationException("Pointer size is " + POINTER_SIZE);
+        };
+    }
+
+    public LinuxIme() {
+        final long glfwWindowPtr = Display.getWindow();
+        GLFW.glfwPollEvents();
+        final long x11Window = GLFWNativeX11.glfwGetX11Window(glfwWindowPtr);
+
+        // On Raven's system it is at 1184 (0x4a0)
+        int windowOffset = 0;
+        for (int i = 64; i < 2048; i += 4) {
+            final int fieldValue = UNSAFE.getInt(glfwWindowPtr + i);
+            if (fieldValue == x11Window) {
+                windowOffset = i;
+                break;
+            }
+            System.err.flush();
+        }
+        if (windowOffset == 0) {
+            throw new RuntimeException("Can't find the X11 window ID offset.");
+        }
+        int xicOffset = windowOffset + 2 * POINTER_SIZE;
+        // XIC is a pointer
+        if ((xicOffset % POINTER_SIZE) != 0) {
+            xicOffset += POINTER_SIZE - (xicOffset % POINTER_SIZE);
+        }
+        xicPtr = glfwWindowPtr + xicOffset;
+
+        SharedLibrary xlib = X11.getLibrary();
+        XVaCreateNestedList_PFN = xlib.getFunctionAddress("XVaCreateNestedList");
+        if (XVaCreateNestedList_PFN == 0) {
+            throw new UnsupportedOperationException("Could not find XVaCreateNestedList");
+        }
+        XGetICValues_PFN = xlib.getFunctionAddress("XGetICValues");
+        if (XGetICValues_PFN == 0) {
+            throw new UnsupportedOperationException("Could not find XGetICValues");
+        }
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            // XVaCreateNestedList(0, XNPreeditState, &state, NULL);
+            XVaCreateNestedList_CIF = APIUtil.apiCreateCIFVar(
+                    FFI_DEFAULT_ABI,
+                    1,
+                    ffi_type_pointer,
+                    ffi_type_sint32,
+                    ffi_type_pointer,
+                    ffi_type_pointer,
+                    ffi_type_pointer);
+
+            // XGetICValues((void*)XIC, XNPreeditAttributes, (XVaNestedList)pr_atrb, NULL);
+            XGetICValues_CIF = APIUtil.apiCreateCIFVar(
+                    FFI_DEFAULT_ABI,
+                    1,
+                    ffi_type_pointer,
+                    ffi_type_pointer,
+                    ffi_type_pointer,
+                    ffi_type_pointer,
+                    ffi_type_pointer);
+        }
+
+        System.out.println("Linux IME native interface intialized");
+    }
+
+    @Override
+    public boolean isCompositionEnabled() {
+        final long xicValue = peekPointer(xicPtr);
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer nestedList = stack.callocPointer(1);
+            final PointerBuffer state = stack.callocPointer(1);
+
+            {
+                final PointerBuffer argValues = stack.pointers(0, memAddress(XNPreeditState), memAddress(state), 0);
+                final PointerBuffer args = stack.pointers(
+                        memAddress(argValues, 0),
+                        memAddress(argValues, 1),
+                        memAddress(argValues, 2),
+                        memAddress(argValues, 3));
+
+                // nestedList = XVaCreateNestedList(0, XNPreeditState, &state, NULL);
+                ffi_call(XVaCreateNestedList_CIF, XVaCreateNestedList_PFN, memByteBuffer(nestedList), args);
+            }
+
+            // ret = XGetICValues(xic, XNPreeditAttributes, nestedList, NULL);
+            {
+                final PointerBuffer argValues = stack
+                        .pointers(xicValue, memAddress(XNPreeditAttributes), nestedList.get(0), 0);
+                final PointerBuffer ret = stack.callocPointer(1);
+                final PointerBuffer args = stack.pointers(
+                        memAddress(argValues, 0),
+                        memAddress(argValues, 1),
+                        memAddress(argValues, 2),
+                        memAddress(argValues, 3));
+                ffi_call(XGetICValues_CIF, XGetICValues_PFN, memByteBuffer(ret), args);
+
+                X11.nXFree(nestedList.get(0));
+
+                if (ret.get(0) != 0) {
+                    System.err.println("Xlib error: " + ret.getStringUTF8(0));
+                    return false;
+                }
+            }
+
+            final long stateValue = state.get(0);
+
+            return stateValue == XIMPreeditEnable;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        XVaCreateNestedList_CIF.close();
+        XGetICValues_CIF.close();
+    }
+}


### PR DESCRIPTION
Current status: X11 implementation, does nothing when IME is off, prints errors when IME is on:
```
[14:34:31] [Client thread/INFO] [STDERR]: [me.eigenraven.lwjgl3ify.ime.impl.LinuxIme:isCompositionEnabled:145]: Xlib error: preeditAttributes
[14:34:31] [Client thread/INFO] [lwjgl3ify]: [DEBUG-KEY] key window:139779262380368 key:32 scancode:65 action:1 mods:0 charname:Space naive-char:  ime-on:false
```
Most likely some XIM attributes need to be changed on the XIC object.

reference impl from AWT: https://github.com/openjdk/jdk/blob/7277bb19f128b84094400cb4262b2e0432e559c5/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c#L1672-L1707
and here's how glfw creates its XIC: https://github.com/glfw/glfw/blob/3.3.8/src/x11_window.c#L773-L780
and this is the entry for the windows api for the future https://learn.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immcreatecontext
