### PR TITLE
LWJGL 3.3.2 stable update

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -4,6 +4,29 @@ def newJavaToolchainSpec = new DefaultToolchainSpec(objects)
 newJavaToolchainSpec.vendor.set(JvmVendorSpec.AZUL)
 newJavaToolchainSpec.languageVersion.set(JavaLanguageVersion.of(17))
 
+def extraJavaArgs = [
+    "--illegal-access=warn",
+     "-Djava.security.manager=allow",
+     "-Dfile.encoding=UTF-8",
+     "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
+     "--add-opens", "java.base/java.net=ALL-UNNAMED",
+     "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+     "--add-opens", "java.base/java.io=ALL-UNNAMED",
+     "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+     "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+     "--add-opens", "java.base/java.text=ALL-UNNAMED",
+     "--add-opens", "java.base/java.util=ALL-UNNAMED",
+     "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
+     "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+     "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
+     "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+     "--add-opens", "java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED",
+     "--add-modules", "jdk.dynalink",
+     "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
+     "--add-modules", "java.sql.rowset",
+     "--add-opens", "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED",
+]
+
 SourceSet forgePatchesSet
 SourceSet hotswapSet
 
@@ -108,7 +131,8 @@ def mmcInstanceFilesZip = tasks.register("mmcInstanceFiles", Zip) {
     from(new File(projectDir, "prism-libraries/"))
     exclude("forgepatches-for-dev-work.json", "META-INF", "META-INF/**")
     filesMatching(["mmc-pack.json", "patches/me.eigenraven.lwjgl3ify.forgepatches.json"]) {
-        expand "version": project.version
+        expand "version": project.version,
+            "jvmArgs": extraJavaArgs.collect { '"' + it + '"' }.join(", ")
     }
 }
 
@@ -143,28 +167,7 @@ afterEvaluate {
 
 def newJavaLauncher = javaToolchains.launcherFor(newJavaToolchainSpec)
 
-minecraft.extraRunJvmArguments.addAll(
-    "--illegal-access=warn",
-    "-Djava.security.manager=allow",
-    "-Dfile.encoding=UTF-8",
-    "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
-    "--add-opens", "java.base/java.net=ALL-UNNAMED",
-    "--add-opens", "java.base/java.nio=ALL-UNNAMED",
-    "--add-opens", "java.base/java.io=ALL-UNNAMED",
-    "--add-opens", "java.base/java.lang=ALL-UNNAMED",
-    "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
-    "--add-opens", "java.base/java.text=ALL-UNNAMED",
-    "--add-opens", "java.base/java.util=ALL-UNNAMED",
-    "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
-    "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
-    "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
-    "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
-    "--add-opens", "java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED",
-    "--add-modules", "jdk.dynalink",
-    "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
-    "--add-modules", "java.sql.rowset",
-    "--add-opens", "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED"
-)
+minecraft.extraRunJvmArguments.addAll(extraJavaArgs)
 
 for (runTask in ["runClient", "runServer"]) {
     tasks.named(runTask, JavaExec).configure {

--- a/addon.gradle
+++ b/addon.gradle
@@ -159,6 +159,7 @@ minecraft.extraRunJvmArguments.addAll(
     "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
     "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
     "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+    "--add-opens", "java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED",
     "--add-modules", "jdk.dynalink",
     "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
     "--add-modules", "java.sql.rowset",

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1679836390
+//version: 1681680742
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -67,20 +67,21 @@ plugins {
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
     id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
     id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
-    id 'com.palantir.git-version' version '0.13.0' apply false // 0.13.0 is the last jvm8 supporting version
+    id 'com.palantir.git-version' version '3.0.0' apply false
     id 'de.undercouch.download' version '5.3.0'
     id 'com.github.gmazzo.buildconfig' version '3.1.0' apply false // Unused, available for addon.gradle
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.3'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.5'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
     throw new GradleException("Settings has been updated, please re-run task.")
 
-if (project.file('.git/HEAD').isFile()) {
+// In submodules, .git is a file pointing to the real git dir
+if (project.file('.git/HEAD').isFile() || project.file('.git').isFile()) {
     apply plugin: 'com.palantir.git-version'
 }
 
@@ -201,6 +202,14 @@ configurations {
         canBeConsumed = false
         canBeResolved = false
     }
+
+    create("devOnlyNonPublishable") {
+        description = "Runtime and compiletime dependencies that are not published alongside the jar (compileOnly + runtimeOnlyNonPublishable)"
+        canBeConsumed = false
+        canBeResolved = false
+    }
+    compileOnly.extendsFrom(devOnlyNonPublishable)
+    runtimeOnlyNonPublishable.extendsFrom(devOnlyNonPublishable)
 }
 
 if (enableModernJavaSyntax.toBoolean()) {
@@ -405,8 +414,6 @@ minecraft {
     extraRunJvmArguments.add("-ea:${modGroup}")
 
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        extraTweakClasses.add("org.spongepowered.asm.launch.MixinTweaker")
-
         if (usesMixinDebug.toBoolean()) {
             extraRunJvmArguments.addAll([
                 "-Dmixin.debug.countInjections=true",
@@ -561,8 +568,9 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.5"
-def mixinProviderSpec = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
+def mixinProviderVersion = "0.1.6"
+def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
+def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -574,8 +582,10 @@ dependencies {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         implementation(mixinProviderSpec)
+    } else if (forceEnableMixins.toBoolean()) {
+        runtimeOnlyNonPublishable(mixinProviderSpec)
     }
 }
 
@@ -591,10 +601,11 @@ pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
 // https://docs.gradle.org/8.0.2/userguide/resolution_rules.html#sec:substitution_with_classifier
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute module('com.gtnewhorizon:gtnhmixins') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
-        substitute module('com.github.GTNewHorizons:Mixingasm') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
-        substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
-        substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
+        substitute module('com.gtnewhorizon:gtnhmixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:Mixingasm') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
     }
 }
 
@@ -809,10 +820,6 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
-
-        if (!(project.usesMixins.toBoolean() || project.forceEnableMixins.toBoolean())) {
-            this.extraArgs.addAll("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
-        }
     }
 }
 
@@ -1390,7 +1397,7 @@ static int replaceParams(File file, Map<String, String> params) {
     return 0
 }
 
-// Dependency Deobfuscation
+// Dependency Deobfuscation (Deprecated, use the new RFG API documented in dependencies.gradle)
 
 def deobf(String sourceURL) {
     try {
@@ -1432,11 +1439,7 @@ def deobfMaven(String repoURL, String mavenDep) {
 }
 
 def deobfCurse(String curseDep) {
-    try {
-        return deobfMaven("https://www.cursemaven.com/", "curse.maven:$curseDep")
-    } catch (Exception ignored) {
-        out.style(Style.Failure).println("Failed to get $curseDep from cursemaven.")
-    }
+    return dependencies.rfg.deobf("curse.maven:$curseDep")
 }
 
 // The method above is to be preferred. Use this method if the filename is not at the end of the URL.
@@ -1444,34 +1447,7 @@ def deobf(String sourceURL, String rawFileName) {
     String bon2Version = "2.5.1"
     String fileName = URLDecoder.decode(rawFileName, "UTF-8")
     String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
-    String bon2Dir = "$cacheDir/forge_gradle/deobf"
-    String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
     String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
-    String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
-
-    if (file(deobfFile).exists()) {
-        return files(deobfFile)
-    }
-
-    String mappingsVer
-    String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
-    if (remoteMappings) {
-        String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
-        String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
-
-        zipMappings(mappingsZIP, remoteMappings, bon2Dir)
-
-        mappingsVer = "snapshot_$id"
-    } else {
-        mappingsVer = "${channel}_$mappingsVersion"
-    }
-
-    download.run {
-        src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
-        dest bon2File
-        quiet true
-        overwrite false
-    }
 
     download.run {
         src sourceURL
@@ -1479,50 +1455,8 @@ def deobf(String sourceURL, String rawFileName) {
         quiet true
         overwrite false
     }
-
-    exec {
-        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
-        workingDir bon2Dir
-        standardOutput = new FileOutputStream("${deobfFile}.log")
-    }
-
-    return files(deobfFile)
+    return dependencies.rfg.deobf(files(obfFile))
 }
-
-def zipMappings(String zipPath, String url, String bon2Dir) {
-    File zipFile = new File(zipPath)
-    if (zipFile.exists()) {
-        return
-    }
-
-    String fieldsCache = "$bon2Dir/data/fields.csv"
-    String methodsCache = "$bon2Dir/data/methods.csv"
-
-    download.run {
-        src "${url}fields.csv"
-        dest fieldsCache
-        quiet true
-    }
-    download.run {
-        src "${url}methods.csv"
-        dest methodsCache
-        quiet true
-    }
-
-    zipFile.getParentFile().mkdirs()
-    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
-
-    zos.putNextEntry(new ZipEntry("fields.csv"))
-    Files.copy(Paths.get(fieldsCache), zos)
-    zos.closeEntry()
-
-    zos.putNextEntry(new ZipEntry("methods.csv"))
-    Files.copy(Paths.get(methodsCache), zos)
-    zos.closeEntry()
-
-    zos.close()
-}
-
 // Helper methods
 
 def checkPropertyExists(String propertyName) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 
 minecraft {
     mainLwjglVersion = 3
-    lwjgl3Version = "3.3.2-SNAPSHOT"
+    lwjgl3Version = "3.3.2"
 }
 
 def addGtForTesting = false
@@ -30,19 +30,19 @@ dependencies {
 
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.3.39-GTNH:dev')
     if (addGtForTesting) {
-        runtimeOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.265:dev')
-        runtimeOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-153-GTNH:dev")
-        runtimeOnly("com.github.GTNewHorizons:Chisel:2.10.16-GTNH:dev")
-        runtimeOnly("com.github.GTNewHorizons:ForestryMC:4.5.6:dev")
-        runtimeOnly("com.github.GTNewHorizons:Railcraft:9.13.14:dev")
-        runtimeOnly("com.github.GTNewHorizons:EnderIO:2.3.1.54:dev")
-        runtimeOnly("com.github.GTNewHorizons:ProjectRed:4.7.9-GTNH:dev") { transitive = false }
-        runtimeOnly("com.github.GTNewHorizons:MrTJPCore:1.1.4:dev")
-        runtimeOnly("com.github.GTNewHorizons:ForgeMultipart:1.3.1:dev")
-        runtimeOnly("com.github.GTNewHorizons:ForgeRelocation:0.0.3:dev")
+        runtimeOnlyNonPublishable('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.265:dev')
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-153-GTNH:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.10.16-GTNH:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.5.6:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Railcraft:9.13.14:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderIO:2.3.1.54:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:ProjectRed:4.7.9-GTNH:dev") { transitive = false }
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:MrTJPCore:1.1.4:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeMultipart:1.3.1:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeRelocation:0.0.3:dev")
         reobfJarConfiguration group: 'curse.maven', name: 'cofh-core-69162', version: '2388750'
-        runtimeOnly("com.github.GTNewHorizons:AppleCore:3.2.9:dev")
-        runtimeOnly("com.github.GTNewHorizons:Hodgepodge:2.0.28:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.2.9:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.0.28:dev")
     }
     if (addReikaModsForTesting) {
         // DragonAPI

--- a/java9args.txt
+++ b/java9args.txt
@@ -25,6 +25,8 @@ java.base/sun.nio.ch=ALL-UNNAMED
 jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming
 --add-opens
 java.desktop/sun.awt.image=ALL-UNNAMED
+--add-opens
+java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED
 --add-modules jdk.dynalink
 --add-opens
 jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED

--- a/prism-libraries/mmc-pack.json
+++ b/prism-libraries/mmc-pack.json
@@ -22,7 +22,7 @@
             "version": "1.7.10"
         },
         {
-            "cachedName": "Forge-J9-Patches",
+            "cachedName": "Forge-lwjgl3ify-Patches",
             "cachedVersion": "${version}",
             "uid": "me.eigenraven.lwjgl3ify.forgepatches"
         },

--- a/prism-libraries/mmc-pack.json
+++ b/prism-libraries/mmc-pack.json
@@ -2,7 +2,7 @@
     "components": [
         {
             "cachedName": "LWJGL 3",
-            "cachedVersion": "3.3.2-SNAPSHOT-3.3.2-20230304.162250-10",
+            "cachedVersion": "3.3.2",
             "cachedVolatile": true,
             "dependencyOnly": true,
             "uid": "org.lwjgl3",

--- a/prism-libraries/patches/me.eigenraven.lwjgl3ify.forgepatches.json
+++ b/prism-libraries/patches/me.eigenraven.lwjgl3ify.forgepatches.json
@@ -20,6 +20,7 @@
         "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
         "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
         "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+        "--add-opens", "java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED",
         "--add-modules", "jdk.dynalink",
         "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
         "--add-modules", "java.sql.rowset",

--- a/prism-libraries/patches/me.eigenraven.lwjgl3ify.forgepatches.json
+++ b/prism-libraries/patches/me.eigenraven.lwjgl3ify.forgepatches.json
@@ -1,30 +1,11 @@
 {
     "formatVersion": 1,
-    "name": "Forge-J9-Patches",
+    "name": "Forge-lwjgl3ify-Patches",
     "uid": "me.eigenraven.lwjgl3ify.forgepatches",
     "version": "${version}",
     "order": 3,
     "+jvmArgs": [
-        "--illegal-access=warn",
-        "-Djava.security.manager=allow",
-        "-Dfile.encoding=UTF-8",
-        "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
-        "--add-opens", "java.base/java.net=ALL-UNNAMED",
-        "--add-opens", "java.base/java.nio=ALL-UNNAMED",
-        "--add-opens", "java.base/java.io=ALL-UNNAMED",
-        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
-        "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
-        "--add-opens", "java.base/java.text=ALL-UNNAMED",
-        "--add-opens", "java.base/java.util=ALL-UNNAMED",
-        "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
-        "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
-        "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
-        "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
-        "--add-opens", "java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED",
-        "--add-modules", "jdk.dynalink",
-        "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
-        "--add-modules", "java.sql.rowset",
-        "--add-opens", "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED"
+        ${jvmArgs}
     ],
     "libraries": [
         {

--- a/prism-libraries/patches/org.lwjgl3.json
+++ b/prism-libraries/patches/org.lwjgl3.json
@@ -2,8 +2,8 @@
     "formatVersion": 1,
     "libraries": [
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.2-SNAPSHOT/lwjgl-glfw-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-glfw-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-glfw-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -14,8 +14,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.2-SNAPSHOT/lwjgl-glfw-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -32,8 +32,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.2-SNAPSHOT/lwjgl-glfw-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-glfw-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-glfw-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -44,8 +44,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.2-SNAPSHOT/lwjgl-glfw-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-glfw-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-glfw-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -56,8 +56,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.2-SNAPSHOT/lwjgl-glfw-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-glfw-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-glfw-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -68,12 +68,12 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-glfw/3.3.2-SNAPSHOT/lwjgl-glfw-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl-glfw:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw.jar",
+            "name": "org.lwjgl:lwjgl-glfw:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.2-SNAPSHOT/lwjgl-jemalloc-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-jemalloc-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -84,8 +84,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.2-SNAPSHOT/lwjgl-jemalloc-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -102,8 +102,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.2-SNAPSHOT/lwjgl-jemalloc-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-jemalloc-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -114,8 +114,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.2-SNAPSHOT/lwjgl-jemalloc-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-jemalloc-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -126,8 +126,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.2-SNAPSHOT/lwjgl-jemalloc-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-jemalloc-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -138,12 +138,12 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-jemalloc/3.3.2-SNAPSHOT/lwjgl-jemalloc-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl-jemalloc:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc.jar",
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.2-SNAPSHOT/lwjgl-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -154,8 +154,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.2-SNAPSHOT/lwjgl-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -172,8 +172,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.2-SNAPSHOT/lwjgl-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -184,8 +184,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.2-SNAPSHOT/lwjgl-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -196,8 +196,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.2-SNAPSHOT/lwjgl-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -208,8 +208,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.2-SNAPSHOT/lwjgl-openal-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-openal-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-openal-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -220,8 +220,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.2-SNAPSHOT/lwjgl-openal-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -238,8 +238,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.2-SNAPSHOT/lwjgl-openal-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-openal-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-openal-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -250,8 +250,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.2-SNAPSHOT/lwjgl-openal-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-openal-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-openal-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -262,8 +262,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.2-SNAPSHOT/lwjgl-openal-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-openal-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-openal-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -274,12 +274,12 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-openal/3.3.2-SNAPSHOT/lwjgl-openal-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl-openal:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal.jar",
+            "name": "org.lwjgl:lwjgl-openal:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.2-SNAPSHOT/lwjgl-opengl-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-opengl-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-opengl-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -290,8 +290,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.2-SNAPSHOT/lwjgl-opengl-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -308,8 +308,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.2-SNAPSHOT/lwjgl-opengl-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-opengl-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-opengl-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -320,8 +320,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.2-SNAPSHOT/lwjgl-opengl-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-opengl-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-opengl-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -332,8 +332,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.2-SNAPSHOT/lwjgl-opengl-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-opengl-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-opengl-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -344,12 +344,12 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-opengl/3.3.2-SNAPSHOT/lwjgl-opengl-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl-opengl:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl.jar",
+            "name": "org.lwjgl:lwjgl-opengl:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.2-SNAPSHOT/lwjgl-stb-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-stb-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-stb-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -360,8 +360,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.2-SNAPSHOT/lwjgl-stb-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -378,8 +378,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.2-SNAPSHOT/lwjgl-stb-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-stb-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-stb-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -390,8 +390,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.2-SNAPSHOT/lwjgl-stb-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-stb-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-stb-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -402,8 +402,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.2-SNAPSHOT/lwjgl-stb-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-stb-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-stb-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -414,12 +414,12 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-stb/3.3.2-SNAPSHOT/lwjgl-stb-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl-stb:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb.jar",
+            "name": "org.lwjgl:lwjgl-stb:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.2-SNAPSHOT/lwjgl-tinyfd-3.3.2-20230304.162250-10-natives-linux.jar",
-            "name": "org.lwjgl:lwjgl-tinyfd-natives-linux:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-linux.jar",
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-linux:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -430,8 +430,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.2-SNAPSHOT/lwjgl-tinyfd-3.3.2-20230304.162250-10-natives-macos-arm64.jar",
-            "name": "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-macos-arm64.jar",
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -448,8 +448,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.2-SNAPSHOT/lwjgl-tinyfd-3.3.2-20230304.162250-10-natives-macos.jar",
-            "name": "org.lwjgl:lwjgl-tinyfd-natives-macos:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-macos.jar",
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-macos:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -460,8 +460,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.2-SNAPSHOT/lwjgl-tinyfd-3.3.2-20230304.162250-10-natives-windows-x86.jar",
-            "name": "org.lwjgl:lwjgl-tinyfd-natives-windows-x86:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-windows-x86.jar",
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-windows-x86:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -472,8 +472,8 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.2-SNAPSHOT/lwjgl-tinyfd-3.3.2-20230304.162250-10-natives-windows.jar",
-            "name": "org.lwjgl:lwjgl-tinyfd-natives-windows:3.3.2-SNAPSHOT-10",
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-windows.jar",
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-windows:3.3.2",
             "rules": [
                 {
                     "action": "allow",
@@ -484,18 +484,18 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl-tinyfd/3.3.2-SNAPSHOT/lwjgl-tinyfd-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl-tinyfd:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd.jar",
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/lwjgl/lwjgl/3.3.2-SNAPSHOT/lwjgl-3.3.2-20230304.162250-10.jar",
-            "name": "org.lwjgl:lwjgl:3.3.2-SNAPSHOT-10"
+            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl.jar",
+            "name": "org.lwjgl:lwjgl:3.3.2"
         }
     ],
     "name": "LWJGL 3",
-    "releaseTime": "2022-11-29T14:28:08+00:00",
+    "releaseTime": "2023-04-01T16:24:00+00:00",
     "type": "release",
     "uid": "org.lwjgl3",
-    "version": "3.3.2-SNAPSHOT-3.3.2-20230304.162250-10",
+    "version": "3.3.2",
     "volatile": true
 }


### PR DESCRIPTION
Update from lwjgl 3.3.2 snapshots to the stable release - currently from upstream builds host because it's not been put in Mojang's repositories yet.