### PR TITLE
Synthesize ASCII escape codes for ctrl+alt+CHAR inputs too

### DIFF
--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -179,7 +179,7 @@ public class Display {
                             // MacOS doesn't send a char event for Cmd+KEY presses, but other platforms do.
                             cancelNextChar = true;
                         }
-                    } else if ((GLFW_MOD_CONTROL & mods) != 0 && (GLFW_MOD_ALT & mods) == 0) { // Handle ctrl + x/c/v.
+                    } else if ((GLFW_MOD_CONTROL & mods) != 0) { // Handle ctrl + x/c/v.
                         Keyboard.addGlfwKeyEvent(window, key, scancode, action, mods, (char) (key & 0x1f));
                         cancelNextChar = true; // Cancel char event from ctrl key since its already handled here
                     } else if (action > 0) { // Delay press and repeat key event to actual char input. There is ALWAYS a


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14421

I don't think the ALT check is actually needed for anything, it was used earlier for a discarded IME switching mechanism.