### PR TITLE
Update to mojang's lwjgl 3.3.2 distribution to match vanilla 1.20.2

### DIFF
--- a/prism-libraries/patches/org.lwjgl3.json
+++ b/prism-libraries/patches/org.lwjgl3.json
@@ -1,8 +1,19 @@
 {
+    "conflicts": [
+        {
+            "uid": "org.lwjgl"
+        }
+    ],
     "formatVersion": 1,
     "libraries": [
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "0766bb0e8e829598b1c8052fd8173c62af741c52",
+                    "size": 115553,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-glfw-natives-linux:3.3.2",
             "rules": [
                 {
@@ -14,7 +25,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "7e35644de1bf324ca9b7d52acd6e0b8d9a6da4ad",
+                    "size": 137535,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -32,7 +49,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "8223ba1b757c43624f03b09ab9d9228c7f6db001",
+                    "size": 140627,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-glfw-natives-macos:3.3.2",
             "rules": [
                 {
@@ -44,7 +67,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "e79c4857a887bd79ba78bdf2d422a7d333028a2d",
+                    "size": 141892,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "17e1f9ec031ef72c2f7825c38eeb3a79c4d8bb17",
+                    "size": 156550,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-glfw-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -56,7 +109,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "01251e3cb7e5d6159334cfb9244f789ce992f03b",
+                    "size": 165947,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-glfw-natives-windows:3.3.2",
             "rules": [
                 {
@@ -68,11 +127,23 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "757920418805fb90bfebb3d46b1d9e7669fca2eb",
+                    "size": 135828,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.2/lwjgl-glfw-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-glfw:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "2bc33176cdfabf34a63df154b80914e8f433316b",
+                    "size": 204677,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-jemalloc-natives-linux:3.3.2",
             "rules": [
                 {
@@ -84,7 +155,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "fe75e1cad7ac1f7af4a071c4b83e39d11b65a1cc",
+                    "size": 142101,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -102,7 +179,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "959ea96ea27cd1ee45943123140fdb55c49e961f",
+                    "size": 153695,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-jemalloc-natives-macos:3.3.2",
             "rules": [
                 {
@@ -114,7 +197,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "598790de603c286dbc4068b27829eacc37592786",
+                    "size": 152780,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "9b07558f81a5d54dfaeb861bab3ccc86bb4477c9",
+                    "size": 148041,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-jemalloc-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -126,7 +239,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "db886c1f9e313c3fa2a25543b99ccd250d3f9fb5",
+                    "size": 180026,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-jemalloc-natives-windows:3.3.2",
             "rules": [
                 {
@@ -138,11 +257,23 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "877e17e39ebcd58a9c956dc3b5b777813de0873a",
+                    "size": 43233,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.2/lwjgl-jemalloc-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-jemalloc:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "767684973f259d97e7dc66a125eb153986f177e7",
+                    "size": 114144,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-natives-linux:3.3.2",
             "rules": [
                 {
@@ -154,7 +285,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "319eea74a8829ce92fd54ce7c684b6b6557c05bb",
+                    "size": 48270,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -172,7 +309,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "3256dce7fa36d6b572afa5e5730f532cf987f3bf",
+                    "size": 60240,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-natives-macos:3.3.2",
             "rules": [
                 {
@@ -184,7 +327,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "d900e4678449ba97ff46fa64b22e0376bf8cd00e",
+                    "size": 133200,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "ed495259b2c8f068794da0ffedfa7ae7c130b3c5",
+                    "size": 139365,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -196,7 +369,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "a55169ced70ffcd15f2162daf4a9c968578f6cd5",
+                    "size": 164993,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-natives-windows:3.3.2",
             "rules": [
                 {
@@ -208,7 +387,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "650981780b8bbfb3ce43657b22ec8e77bfb1f37a",
+                    "size": 579919,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-openal-natives-linux:3.3.2",
             "rules": [
                 {
@@ -220,7 +405,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "7b43d16069bdabc9ca0923ec8756a51c5d61cb75",
+                    "size": 467151,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -238,7 +429,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "56fa16d15039142634e3a6d97d638b56679be821",
+                    "size": 515159,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-openal-natives-macos:3.3.2",
             "rules": [
                 {
@@ -250,7 +447,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "545ddec7959007a78b6662d616e00dacf00e1c29",
+                    "size": 627059,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "21fcb44d32ccf101017ec939fc740197677557d5",
+                    "size": 636273,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-openal-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -262,7 +489,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "e74f299a602192faaf14b917632e4cbbb493c940",
+                    "size": 694908,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-openal-natives-windows:3.3.2",
             "rules": [
                 {
@@ -274,11 +507,23 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "ae5357ed6d934546d3533993ea84c0cfb75eed95",
+                    "size": 108230,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.2/lwjgl-openal-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-openal:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "b8368430ef0d91a5acbc6fbfa47b20c3ec083aec",
+                    "size": 80464,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-opengl-natives-linux:3.3.2",
             "rules": [
                 {
@@ -290,7 +535,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "baadfd67936dcd7e0334dd3a9cf8dd13a0bcb009",
+                    "size": 42490,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -308,7 +559,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "05141389ca737369f317b1288a570534c40db9cf",
+                    "size": 41485,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-opengl-natives-macos:3.3.2",
             "rules": [
                 {
@@ -320,7 +577,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "21df035bf03dbf5001f92291b24dc951da513481",
+                    "size": 83132,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "22fa4149159154b24f6c1bd46a342d4958a9fba1",
+                    "size": 88610,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-opengl-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -332,7 +619,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "83cd34469d4e0bc335bf74c7f62206530a9480bf",
+                    "size": 101530,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-opengl-natives-windows:3.3.2",
             "rules": [
                 {
@@ -344,11 +637,23 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "ee8e95be0b438602038bc1f02dc5e3d011b1b216",
+                    "size": 928871,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.2/lwjgl-opengl-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-opengl:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "5c987f43b342d722b54970159040af76f1c87403",
+                    "size": 231821,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-stb-natives-linux:3.3.2",
             "rules": [
                 {
@@ -360,7 +665,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "db49f0f76e8377520b625c688cd45aacb3dcdc9b",
+                    "size": 183630,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -378,7 +689,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "61614cb49cee0b95587893a36bd72f63ab815c82",
+                    "size": 216457,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-stb-natives-macos:3.3.2",
             "rules": [
                 {
@@ -390,7 +707,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "c29df97c3cca97dc00d34e171936153764c9f78b",
+                    "size": 218460,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "a0de7bde6722fa68d25ba6afbd7395508c53c730",
+                    "size": 227583,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-stb-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -402,7 +749,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "1c4f4b8353bdb78c5264ab921436f03fc9aa1ba5",
+                    "size": 261137,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-stb-natives-windows:3.3.2",
             "rules": [
                 {
@@ -414,11 +767,23 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "a2550795014d622b686e9caac50b14baa87d2c70",
+                    "size": 118874,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.2/lwjgl-stb-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-stb:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-linux.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "05d27fc67172b3fcd8400d61a7cfb75da881f609",
+                    "size": 43961,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-linux.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-tinyfd-natives-linux:3.3.2",
             "rules": [
                 {
@@ -430,7 +795,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-macos-arm64.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "0b4aa34d244c75bcbb78d6cdb0b41200348da330",
+                    "size": 41812,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-macos-arm64.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.2",
             "rules": [
                 {
@@ -448,7 +819,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-macos.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "ce88dcda2fffe5d912de8ea1dabd68490a8f8471",
+                    "size": 45096,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-macos.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-tinyfd-natives-macos:3.3.2",
             "rules": [
                 {
@@ -460,7 +837,37 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-windows-x86.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "500f5daa3b731ca282d4b90aeafda94c528d3e27",
+                    "size": 110758,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.3.2",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "0c1dfa1c438e0262453e7bf625289540e5cbffb2",
+                    "size": 111596,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows-x86.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-tinyfd-natives-windows-x86:3.3.2",
             "rules": [
                 {
@@ -472,7 +879,13 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-windows.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "54a93ed247d20007a6f579355263fdc2c030753a",
+                    "size": 130126,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2-natives-windows.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-tinyfd-natives-windows:3.3.2",
             "rules": [
                 {
@@ -484,16 +897,281 @@
             ]
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "9f65c248dd77934105274fcf8351abb75b34327c",
+                    "size": 13404,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.2/lwjgl-tinyfd-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl-tinyfd:3.3.2"
         },
         {
-            "MMC-absoluteUrl": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl.jar",
+            "downloads": {
+                "artifact": {
+                    "sha1": "4421d94af68e35dcaa31737a6fc59136a1e61b94",
+                    "size": 786196,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.2/lwjgl-3.3.2.jar"
+                }
+            },
             "name": "org.lwjgl:lwjgl:3.3.2"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "bc49e64bae0f7ff103a312ee8074a34c4eb034c7",
+                    "size": 120168,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "5907d9a6b7c44fb0612a63bb1cff5992588f65be",
+                    "size": 110067,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-glfw/lwjgl-glfw-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "5249f18a9ae20ea86c5816bc3107a888ce7a17d2",
+                    "size": 206402,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "9367437ce192e4d6f5725d53d85520644c0b0d6f",
+                    "size": 177571,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-jemalloc/lwjgl-jemalloc-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "22408980cc579709feaf9acb807992d3ebcf693f",
+                    "size": 590865,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "7c82bbc33ef49ee4094b216c940db564b2998224",
+                    "size": 503352,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-openal/lwjgl-openal-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "bb9eb56da6d1d549d6a767218e675e36bc568eb9",
+                    "size": 58627,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "821f9a2d1d583c44893f42b96f6977682b48a99b",
+                    "size": 59265,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-opengl/lwjgl-opengl-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "11a380c37b0f03cb46db235e064528f84d736ff7",
+                    "size": 207419,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "ca9333da184aade20757151f4615f1e27ca521ae",
+                    "size": 154928,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-stb/lwjgl-stb-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "93f8c5bc1984963cd79109891fb5a9d1e580373e",
+                    "size": 43381,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "807e220913aa0740449ff90d3b3d825cf5f359ed",
+                    "size": 48788,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl-tinyfd/lwjgl-tinyfd-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "8bd89332c90a90e6bc4aa997a25c05b7db02c90a",
+                    "size": 90795,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-linux-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-natives-linux-arm64:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm64"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "sha1": "afcbfaaa46f217e98a6da4208550f71de1f2a225",
+                    "size": 89347,
+                    "url": "https://build.lwjgl.org/release/3.3.2/bin/lwjgl/lwjgl-natives-linux-arm32.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-natives-linux-arm32:3.3.2-lwjgl.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux-arm32"
+                    }
+                }
+            ]
         }
     ],
     "name": "LWJGL 3",
-    "releaseTime": "2023-04-01T16:24:00+00:00",
+    "order": -1,
+    "releaseTime": "2023-09-18T12:34:57+00:00",
     "type": "release",
     "uid": "org.lwjgl3",
     "version": "3.3.2",


### PR DESCRIPTION
Now that mojang published vanilla 1.20.2 we can use the upstream JSON for lwjgl 3.3.2: <https://github.com/PrismLauncher/meta-launcher/blob/master/org.lwjgl3/3.3.2.json>