### PR TITLE
Installation simplification and ASM upgrade

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,7 @@ There are a few components to enabling modern java and lwjgl usage on old minecr
  - `UnsafeHacks` class from modern forge, modified to work in more usecases, for replacing some `static final` writes where it was not feasible/easy to remove final.
  - Forge patches, which are modified classes from Forge that cannot be transformed because they are loaded too early - so we load a `forgePatches` jar before Forge in the classpath to replace them:
    - EventSubscriptionTransformer: the format of subclass annotation descriptors has slightly changed in Java 17, this makes the annotation discovery compatible with both
+   - TerminalTransformer: modify to accept classfiles newer than what asm5 supported
    - ClassPatchManager: switches the Pack200 implementation to an Apache Commons Compress one because it was removed from newer JDKs
    - TracingPrintStream: commons-compress closes System.out, this blocks this from happening
    - CoreModManager: work around the fact that the system classloader is no longer a URLClassLoader

--- a/README.MD
+++ b/README.MD
@@ -4,10 +4,15 @@ Brings LWJGL3 and modern Java versions to Minecraft 1.7.10.
 
 # Usage
 
-Lwjgl3ify depends on Unimixins (<https://github.com/LegacyModdingMC/UniMixins/>), use at least version 0.1.5 with the GTNHMixins module.
-Hodgepodge (<https://github.com/GTNewHorizons/Hodgepodge>) is strongly recommended, it has many Java 9+ compatibility patches for ARR mods (Biomes'o'Plenty, Witchery, JourneyMap, and more) which we could not directly fix in the GTNH forks.
+Lwjgl3ify depends on Unimixins (<https://github.com/LegacyModdingMC/UniMixins/>), use at least version 0.1.7 with the GTNHMixins module.
+Hodgepodge (<https://github.com/GTNewHorizons/Hodgepodge>) is strongly recommended, it has many Java 17+ compatibility patches for ARR mods (Biomes'o'Plenty, Witchery, JourneyMap, and more) which we could not directly fix in the GTNH forks.
 
 ## Client
+
+### Non-GTNH 1.7.10 instance setup
+
+**If you are using a GregTech New Horizons pre-packaged Java 17+ instance, skip to the next section!**
+
 To install in PrismLauncher or MultiMC:
 
 Copy the contents of `lwjgl3ify-VERSION-multimc.zip` to `instances/My Modpack/`. `mmc-pack.json` needs to be overwritten.
@@ -15,21 +20,24 @@ Reload the launcher, and it should show up modified versions of Forge, Minecraft
 Put the mod jar (`lwjgl3ify-VERSION.jar`) in `mods/` in your instance's minecraft folder, it will get loaded as a coremod.
 The forgePatches jar will get automatically downloaded by the launcher.
 
-Change the instance java version to 17.0.6 (or newer), 19.0.2 (or newer) or 20 (or newer), these are the currently supported versions.
+Change the instance java version to 17.0.6, 19.0.2, 20 or 21 (or newer), these are the currently supported versions.
 You can also use Java 11 if you remove the `-Djava.security.manager=allow` argument from `patches/me.eigenraven.lwjgl3ify.forgepatches.json`.
 
+### MultiMC setup (GTNH and non-GTNH)
 For MultiMC, you need to manually put in extra java arguments, prismlauncher can load them from the patches json files automatically:
 ```
 --illegal-access=warn -Djava.security.manager=allow -Dfile.encoding=UTF-8 --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming --add-opens java.desktop/sun.awt.image=ALL-UNNAMED --add-modules jdk.dynalink --add-opens jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED --add-modules java.sql.rowset --add-opens java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED
 ```
 
+### Tweaking configs
 If you want to tweak your default window size, OpenGL context properties or other more advanced settings, check out the config file in `config/lwjgl3ify.cfg` after the first startup.
 
 ## Server
-Install the mod jar in `mods/`, and download the `forgePatches` jar. Put the forgePatches jar in the same folder as your forge-universal and minecraft server jars.
-Lwjgl3ify also depends on GTNHMixins (<https://github.com/GTNewHorizons/GTNHmixins>), use at least version 2.1.10.
+First, install a working 1.7.10 Forge server, from a modpack zip or using forge's installer.
+Then, install the mod jar (and unimixins, hodgepodge and gtnhlib as needed) in `mods/`, and download the `forgePatches` jar. Put the forgePatches jar in the same folder as your forge-universal and minecraft server jars.
+**Thermos/Crucible/Hybrid servers are not supported!**.
+Lwjgl3ify also depends on Unimixins (<https://github.com/LegacyModdingMC/UniMixins/>), use at least version 0.1.7.
 Rename the forgePatches jar to just `lwjgl3ify-forgePatches.jar`. Create a file named `java9args.txt` with the contents of [the file in this repository](java9args.txt).
-You will also need to install updated libraries in the `libraries` folder, the easiest way it to copy them over from your client launcher.
 You can now launch the server with a command like the following, assuming the first java executable on your PATH is java 11/17/19:
 ```
 java -Xmx6G -Xms6G @java9args.txt nogui
@@ -138,20 +146,16 @@ This can lead to inconsistent states, where some methods might see the old value
 
 ### Development
 
-For developing locally, modify the `patches/me.eigenraven.lwjgl3ify.forgepatches.json` file with the following content:
+First, do `./gradlew build` and use the zip in `./build/distributions/lwjgl3ify-VERSION-multimc.zip` to install lwjgl3ify into a 1.7.10 forge instance in Prism.
+
+Then, for developing locally, in the `patches/me.eigenraven.lwjgl3ify.forgepatches.json` file replace:
 ```json
-{
-    "formatVersion": 1,
-    "name": "Forge-J9-Patches",
-    "uid": "me.eigenraven.lwjgl3ify.forgepatches",
-    "version": "1",
-    "order": 3,
-    "libraries": [
-        {
-            "name": "com.gtnewhorizons:lwjgl3ify:1.2.1:forgePatches",
-            "MMC-hint": "local"
-        }
-    ]
-}
+"url": "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
 ```
-Thanks to `MMC-hint` you can now put the locally built forgePatches jar into `instances/My Modpack/libraries/lwjgl3ify-1.2.1-forgePatches.jar`.
+with:
+```json
+"MMC-hint": "local"
+```
+Inside the libraries array.
+
+Thanks to `MMC-hint` you can now put the locally built forgePatches jar into `instances/My Modpack/libraries/lwjgl3ify-VERSION-forgePatches.jar`.

--- a/addon.gradle
+++ b/addon.gradle
@@ -71,8 +71,8 @@ repositories {
 }
 
 dependencies {
-    utilImplementation("org.ow2.asm:asm:9.4")
-    utilImplementation("org.ow2.asm:asm-tree:9.4")
+    utilImplementation("org.ow2.asm:asm:9.5")
+    utilImplementation("org.ow2.asm:asm-tree:9.5")
     utilImplementation("org.apache.commons:commons-lang3:3.12.0")
     utilImplementation("commons-io:commons-io:2.11.0")
     utilImplementation("commons-collections:commons-collections:3.2.2")
@@ -95,11 +95,11 @@ def forgePatchesJar = tasks.register(forgePatchesSet.jarTaskName, Jar) {
     manifest {
         def libraryList = [
             "libraries/net/minecraft/launchwrapper/1.15/launchwrapper-1.15.jar",
-            "libraries/org/ow2/asm/asm/9.4/asm-9.4.jar",
-            "libraries/org/ow2/asm/asm-commons/9.4/asm-commons-9.4.jar",
-            "libraries/org/ow2/asm/asm-tree/9.4/asm-tree-9.4.jar",
-            "libraries/org/ow2/asm/asm-analysis/9.4/asm-analysis-9.4.jar",
-            "libraries/org/ow2/asm/asm-util/9.4/asm-util-9.4.jar",
+            "libraries/org/ow2/asm/asm/9.5/asm-9.5.jar",
+            "libraries/org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar",
+            "libraries/org/ow2/asm/asm-tree/9.5/asm-tree-9.5.jar",
+            "libraries/org/ow2/asm/asm-analysis/9.5/asm-analysis-9.5.jar",
+            "libraries/org/ow2/asm/asm-util/9.5/asm-util-9.5.jar",
             "libraries/org/ow2/asm/asm-deprecated/7.1/asm-deprecated-7.1.jar",
             "libraries/com/typesafe/akka/akka-actor_2.11/2.3.3/akka-actor_2.11-2.3.3.jar",
             "libraries/com/typesafe/config/1.2.1/config-1.2.1.jar",

--- a/addon.gradle
+++ b/addon.gradle
@@ -52,6 +52,15 @@ sourceSets {
     }
 }
 
+configurations {
+    def forgePatchesEmbedded = create("forgePatchesEmbedded") {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+    forgePatchesImplementation.extendsFrom(forgePatchesEmbedded)
+    patchedMinecraft.extendsFrom(forgePatchesEmbedded)
+}
+
 tasks.named("shadowJar", Jar) {
     from(hotswapSet.output)
 }
@@ -78,29 +87,24 @@ dependencies {
     utilImplementation("commons-collections:commons-collections:3.2.2")
     utilImplementation("com.google.guava:guava:31.1-jre")
 
-    forgePatchesImplementation("org.apache.commons:commons-compress:1.21")
-
     hotswapCompileOnly("org.hotswapagent:hotswap-agent-core:1.4.1")
     hotswapCompileOnly("net.minecraft:launchwrapper:1.15")
 }
 
 def forgePatchesJar = tasks.register(forgePatchesSet.jarTaskName, Jar) {
     from(forgePatchesSet.output)
-    def resolvable = configurations.detachedConfiguration(dependencies.create("org.apache.commons:commons-compress:1.21"))
     // Bootleg shadow jar
-    resolvable.resolve().each {dep ->
-        from(zipTree(dep))
+    configurations.forgePatchesEmbedded.resolve().each {dep ->
+        from(zipTree(dep)) {
+            filesMatching("META-INF/*") { fcd ->
+                fcd.name = "${dep.name}-${fcd.name}"
+            }
+        }
     }
+    exclude("module-info.class")
     archiveClassifier.set("forgePatches")
     manifest {
         def libraryList = [
-            "libraries/net/minecraft/launchwrapper/1.15/launchwrapper-1.15.jar",
-            "libraries/org/ow2/asm/asm/9.5/asm-9.5.jar",
-            "libraries/org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar",
-            "libraries/org/ow2/asm/asm-tree/9.5/asm-tree-9.5.jar",
-            "libraries/org/ow2/asm/asm-analysis/9.5/asm-analysis-9.5.jar",
-            "libraries/org/ow2/asm/asm-util/9.5/asm-util-9.5.jar",
-            "libraries/org/ow2/asm/asm-deprecated/7.1/asm-deprecated-7.1.jar",
             "libraries/com/typesafe/akka/akka-actor_2.11/2.3.3/akka-actor_2.11-2.3.3.jar",
             "libraries/com/typesafe/config/1.2.1/config-1.2.1.jar",
             "libraries/org/scala-lang/scala-actors-migration_2.11/1.1.0/scala-actors-migration_2.11-1.1.0.jar",
@@ -115,7 +119,6 @@ def forgePatchesJar = tasks.register(forgePatchesSet.jarTaskName, Jar) {
             "libraries/lzma/lzma/0.0.1/lzma-0.0.1.jar",
             "libraries/net/sf/jopt-simple/jopt-simple/4.5/jopt-simple-4.5.jar",
             "libraries/com/google/guava/guava/17.0/guava-17.0.jar",
-            "libraries/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
             "forge-1.7.10-10.13.4.1614-1.7.10-universal.jar",
             "minecraft_server.1.7.10.jar"
         ]

--- a/addon.late.gradle
+++ b/addon.late.gradle
@@ -1,0 +1,4 @@
+
+// Regular runClient/runServer tasks run in Java 17 in this project.
+tasks.named("runClient17") { enabled = false }
+tasks.named("runServer17") { enabled = false }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,21 +7,23 @@ minecraft {
 def addGtForTesting = false
 def addReikaModsForTesting = false
 
+def asmVersion = '9.5'
+
 dependencies {
     // Resolve newer versions of LaunchWrapper to allow java 9+ compat
     vanilla_minecraft('net.minecraft:launchwrapper:1.15') { transitive = false }
     patchedMinecraft('net.minecraft:launchwrapper:1.15') { transitive = false }
 
-    patchedMinecraft('org.ow2.asm:asm:9.4')
-    patchedMinecraft('org.ow2.asm:asm-commons:9.4')
-    patchedMinecraft('org.ow2.asm:asm-tree:9.4')
-    patchedMinecraft('org.ow2.asm:asm-analysis:9.4')
-    patchedMinecraft('org.ow2.asm:asm-util:9.4')
+    patchedMinecraft("org.ow2.asm:asm:${asmVersion}")
+    patchedMinecraft("org.ow2.asm:asm-commons:${asmVersion}")
+    patchedMinecraft("org.ow2.asm:asm-tree:${asmVersion}")
+    patchedMinecraft("org.ow2.asm:asm-analysis:${asmVersion}")
+    patchedMinecraft("org.ow2.asm:asm-util:${asmVersion}")
     patchedMinecraft('org.ow2.asm:asm-deprecated:7.1')
     patchedMinecraft("org.apache.commons:commons-lang3:3.12.0")
 
     // Allow using Unsafe with newer javac versions
-    patchedMinecraft('me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0')
+    compileOnly('me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0')
 
     shadowImplementation("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
     shadowImplementation("jakarta.servlet:jakarta.servlet-api:6.0.0")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,16 +11,18 @@ def asmVersion = '9.5'
 
 dependencies {
     // Resolve newer versions of LaunchWrapper to allow java 9+ compat
-    vanilla_minecraft('net.minecraft:launchwrapper:1.15') { transitive = false }
-    patchedMinecraft('net.minecraft:launchwrapper:1.15') { transitive = false }
+    vanilla_minecraft('net.minecraft:launchwrapper:1.17.3') { transitive = false }
+    forgePatchesEmbedded('net.minecraft:launchwrapper:1.17.3') { transitive = false }
 
-    patchedMinecraft("org.ow2.asm:asm:${asmVersion}")
-    patchedMinecraft("org.ow2.asm:asm-commons:${asmVersion}")
-    patchedMinecraft("org.ow2.asm:asm-tree:${asmVersion}")
-    patchedMinecraft("org.ow2.asm:asm-analysis:${asmVersion}")
-    patchedMinecraft("org.ow2.asm:asm-util:${asmVersion}")
-    patchedMinecraft('org.ow2.asm:asm-deprecated:7.1')
-    patchedMinecraft("org.apache.commons:commons-lang3:3.12.0")
+    forgePatchesEmbedded("org.ow2.asm:asm:${asmVersion}")
+    forgePatchesEmbedded("org.ow2.asm:asm-commons:${asmVersion}")
+    forgePatchesEmbedded("org.ow2.asm:asm-tree:${asmVersion}")
+    forgePatchesEmbedded("org.ow2.asm:asm-analysis:${asmVersion}")
+    forgePatchesEmbedded("org.ow2.asm:asm-util:${asmVersion}")
+    forgePatchesEmbedded('org.ow2.asm:asm-deprecated:7.1')
+    forgePatchesEmbedded("org.apache.commons:commons-lang3:3.12.0")
+
+    forgePatchesEmbedded("org.apache.commons:commons-compress:1.21")
 
     // Allow using Unsafe with newer javac versions
     compileOnly('me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0')

--- a/prism-libraries/patches/net.minecraft.json
+++ b/prism-libraries/patches/net.minecraft.json
@@ -188,16 +188,6 @@
         {
             "downloads": {
                 "artifact": {
-                    "sha1": "905075e6c80f206bbe6cf1e809d2caa69f420c76",
-                    "size": 315805,
-                    "url": "https://libraries.minecraft.net/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar"
-                }
-            },
-            "name": "org.apache.commons:commons-lang3:3.1"
-        },
-        {
-            "downloads": {
-                "artifact": {
                     "sha1": "b1b6ea3b7e4aa4f492509a4952029cd8e48019ad",
                     "size": 185140,
                     "url": "https://libraries.minecraft.net/commons-io/commons-io/2.4/commons-io-2.4.jar"

--- a/prism-libraries/patches/net.minecraftforge.json
+++ b/prism-libraries/patches/net.minecraftforge.json
@@ -9,69 +9,6 @@
             "url": "https://maven.minecraftforge.net/"
         },
         {
-            "name": "net.minecraft:launchwrapper:1.15",
-            "url": "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-        },
-        {
-            "downloads": {
-                "artifact": {
-                    "path": "org/ow2/asm/asm/9.5/asm-9.5.jar",
-                    "sha1": "dc6ea1875f4d64fbc85e1691c95b96a3d8569c90",
-                    "size": 121863,
-                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm/9.5/asm-9.5.jar"
-                }
-            },
-            "name": "org.ow2.asm:asm:9.5"
-        },
-        {
-            "downloads": {
-                "artifact": {
-                    "path": "org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar",
-                    "sha1": "19ab5b5800a3910d30d3a3e64fdb00fd0cb42de0",
-                    "size": 72209,
-                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar"
-                }
-            },
-            "name": "org.ow2.asm:asm-commons:9.5"
-        },
-        {
-            "downloads": {
-                "artifact": {
-                    "path": "org/ow2/asm/asm-tree/9.5/asm-tree-9.5.jar",
-                    "sha1": "fd33c8b6373abaa675be407082fdfda35021254a",
-                    "size": 51944,
-                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-tree/9.5/asm-tree-9.5.jar"
-                }
-            },
-            "name": "org.ow2.asm:asm-tree:9.5"
-        },
-        {
-            "downloads": {
-                "artifact": {
-                    "path": "org/ow2/asm/asm-util/9.5/asm-util-9.5.jar",
-                    "sha1": "64b5a1fc8c1b15ed2efd6a063e976bc8d3dc5ffe",
-                    "size": 91076,
-                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-util/9.5/asm-util-9.5.jar"
-                }
-            },
-            "name": "org.ow2.asm:asm-util:9.5"
-        },
-        {
-            "downloads": {
-                "artifact": {
-                    "path": "org/ow2/asm/asm-analysis/9.5/asm-analysis-9.5.jar",
-                    "sha1": "490bacc77de7cbc0be1a30bb3471072d705be4a4",
-                    "size": 33978,
-                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-analysis/9.5/asm-analysis-9.5.jar"
-                }
-            },
-            "name": "org.ow2.asm:asm-analysis:9.5"
-        },
-        {
-            "name": "org.ow2.asm:asm-deprecated:7.1",
-            "url": "https://maven.minecraftforge.net/"
-        },
-        {
             "name": "com.typesafe.akka:akka-actor_2.11:2.3.3",
             "url": "https://maven.minecraftforge.net/"
         },
@@ -120,9 +57,6 @@
         },
         {
             "name": "com.google.guava:guava:17.0"
-        },
-        {
-            "name": "org.apache.commons:commons-lang3:3.12.0"
         }
     ],
     "mainClass": "net.minecraft.launchwrapper.Launch",

--- a/prism-libraries/patches/net.minecraftforge.json
+++ b/prism-libraries/patches/net.minecraftforge.json
@@ -13,24 +13,59 @@
             "url": "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         },
         {
-            "name": "org.ow2.asm:asm:9.4",
-            "url": "https://maven.minecraftforge.net/"
+            "downloads": {
+                "artifact": {
+                    "path": "org/ow2/asm/asm/9.5/asm-9.5.jar",
+                    "sha1": "dc6ea1875f4d64fbc85e1691c95b96a3d8569c90",
+                    "size": 121863,
+                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm/9.5/asm-9.5.jar"
+                }
+            },
+            "name": "org.ow2.asm:asm:9.5"
         },
         {
-            "name": "org.ow2.asm:asm-commons:9.4",
-            "url": "https://maven.minecraftforge.net/"
+            "downloads": {
+                "artifact": {
+                    "path": "org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar",
+                    "sha1": "19ab5b5800a3910d30d3a3e64fdb00fd0cb42de0",
+                    "size": 72209,
+                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar"
+                }
+            },
+            "name": "org.ow2.asm:asm-commons:9.5"
         },
         {
-            "name": "org.ow2.asm:asm-tree:9.4",
-            "url": "https://maven.minecraftforge.net/"
+            "downloads": {
+                "artifact": {
+                    "path": "org/ow2/asm/asm-tree/9.5/asm-tree-9.5.jar",
+                    "sha1": "fd33c8b6373abaa675be407082fdfda35021254a",
+                    "size": 51944,
+                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-tree/9.5/asm-tree-9.5.jar"
+                }
+            },
+            "name": "org.ow2.asm:asm-tree:9.5"
         },
         {
-            "name": "org.ow2.asm:asm-analysis:9.4",
-            "url": "https://maven.minecraftforge.net/"
+            "downloads": {
+                "artifact": {
+                    "path": "org/ow2/asm/asm-util/9.5/asm-util-9.5.jar",
+                    "sha1": "64b5a1fc8c1b15ed2efd6a063e976bc8d3dc5ffe",
+                    "size": 91076,
+                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-util/9.5/asm-util-9.5.jar"
+                }
+            },
+            "name": "org.ow2.asm:asm-util:9.5"
         },
         {
-            "name": "org.ow2.asm:asm-util:9.4",
-            "url": "https://maven.minecraftforge.net/"
+            "downloads": {
+                "artifact": {
+                    "path": "org/ow2/asm/asm-analysis/9.5/asm-analysis-9.5.jar",
+                    "sha1": "490bacc77de7cbc0be1a30bb3471072d705be4a4",
+                    "size": 33978,
+                    "url": "https://maven.minecraftforge.net/org/ow2/asm/asm-analysis/9.5/asm-analysis-9.5.jar"
+                }
+            },
+            "name": "org.ow2.asm:asm-analysis:9.5"
         },
         {
             "name": "org.ow2.asm:asm-deprecated:7.1",

--- a/src/forgePatches/java/cpw/mods/fml/common/asm/transformers/TerminalTransformer.java
+++ b/src/forgePatches/java/cpw/mods/fml/common/asm/transformers/TerminalTransformer.java
@@ -1,0 +1,147 @@
+package cpw.mods.fml.common.asm.transformers;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import cpw.mods.fml.relauncher.FMLRelaunchLog;
+import cpw.mods.fml.relauncher.FMLSecurityManager.ExitTrappedException;
+
+public class TerminalTransformer implements IClassTransformer {
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if (basicClass == null) return null;
+        ClassReader reader = new ClassReader(basicClass);
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+
+        ClassVisitor visitor = writer;
+        visitor = new ExitVisitor(visitor);
+
+        reader.accept(visitor, 0);
+        return writer.toByteArray();
+    }
+
+    public static class ExitVisitor extends ClassVisitor {
+
+        private String clsName = null;
+        private static final String callbackOwner = org.objectweb.asm.Type.getInternalName(ExitVisitor.class);
+
+        private ExitVisitor(ClassVisitor cv) {
+            super(Opcodes.ASM5, cv);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName,
+            String[] interfaces) {
+            super.visit(version, access, name, signature, superName, interfaces);
+            this.clsName = name;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int mAccess, final String mName, final String mDesc, String mSignature,
+            String[] mExceptions) {
+            final boolean warn = !(clsName.equals("net/minecraft/client/Minecraft")
+                || clsName.equals("net/minecraft/server/dedicated/DedicatedServer")
+                || clsName.equals("cpw/mods/fml/common/FMLCommonHandler")
+                || clsName.startsWith("com/jcraft/jogg/")
+                || clsName.startsWith("scala/sys/"));
+
+            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(mAccess, mName, mDesc, mSignature, mExceptions)) {
+
+                @Override
+                public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean isIntf) {
+                    if (opcode == Opcodes.INVOKESTATIC && owner.equals("java/lang/System")
+                        && name.equals("exit")
+                        && desc.equals("(I)V")) {
+                        if (warn) {
+                            FMLRelaunchLog.warning("=============================================================");
+                            FMLRelaunchLog.warning(
+                                "MOD HAS DIRECT REFERENCE System.exit() THIS IS NOT ALLOWED REROUTING TO FML!");
+                            FMLRelaunchLog.warning("Offendor: %s.%s%s", ExitVisitor.this.clsName, mName, mDesc);
+                            FMLRelaunchLog.warning("Use FMLCommonHandler.exitJava instead");
+                            FMLRelaunchLog.warning("=============================================================");
+                        }
+                        owner = ExitVisitor.callbackOwner;
+                        name = "systemExitCalled";
+                    } else if (opcode == Opcodes.INVOKEVIRTUAL && owner.equals("java/lang/Runtime")
+                        && name.equals("exit")
+                        && desc.equals("(I)V")) {
+                            if (warn) {
+                                FMLRelaunchLog.warning("=============================================================");
+                                FMLRelaunchLog.warning(
+                                    "MOD HAS DIRECT REFERENCE Runtime.exit() THIS IS NOT ALLOWED REROUTING TO FML!");
+                                FMLRelaunchLog.warning("Offendor: %s.%s%s", ExitVisitor.this.clsName, mName, mDesc);
+                                FMLRelaunchLog.warning("Use FMLCommonHandler.exitJava instead");
+                                FMLRelaunchLog.warning("=============================================================");
+                            }
+                            opcode = Opcodes.INVOKESTATIC;
+                            owner = ExitVisitor.callbackOwner;
+                            name = "runtimeExitCalled";
+                            desc = "(Ljava/lang/Runtime;I)V";
+                        } else if (opcode == Opcodes.INVOKEVIRTUAL && owner.equals("java/lang/Runtime")
+                            && name.equals("halt")
+                            && desc.equals("(I)V")) {
+                                if (warn) {
+                                    FMLRelaunchLog
+                                        .warning("=============================================================");
+                                    FMLRelaunchLog.warning(
+                                        "MOD HAS DIRECT REFERENCE Runtime.halt() THIS IS NOT ALLOWED REROUTING TO FML!");
+                                    FMLRelaunchLog.warning("Offendor: %s.%s%s", ExitVisitor.this.clsName, mName, mDesc);
+                                    FMLRelaunchLog.warning("Use FMLCommonHandler.exitJava instead");
+                                    FMLRelaunchLog
+                                        .warning("=============================================================");
+                                }
+                                opcode = Opcodes.INVOKESTATIC;
+                                owner = ExitVisitor.callbackOwner;
+                                name = "runtimeHaltCalled";
+                                desc = "(Ljava/lang/Runtime;I)V";
+                            }
+
+                    super.visitMethodInsn(opcode, owner, name, desc, isIntf);
+                }
+            };
+        }
+
+        // Intercept System.exit, and check if the caller is allowed to use it, if not wrap it in a ExitTrappedException
+        public static void systemExitCalled(int status) {
+            ExitVisitor.checkAccess();
+            System.exit(status);
+        }
+
+        // Intercept Runtime.getRuntime().exit, and check if the caller is allowed to use it, if not wrap it in a
+        // ExitTrappedException
+        public static void runtimeExitCalled(Runtime runtime, int status) {
+            ExitVisitor.checkAccess();
+            runtime.exit(status);
+        }
+
+        // Intercept Runtime.getRuntime().halt, and check if the caller is allowed to use it, if not wrap it in a
+        // ExitTrappedException
+        public static void runtimeHaltCalled(Runtime runtime, int status) {
+            ExitVisitor.checkAccess();
+            runtime.halt(status);
+        }
+
+        private static void checkAccess() {
+            StackTraceElement[] cause = Thread.currentThread()
+                .getStackTrace();
+
+            String callingClass = cause.length > 2 ? cause[3].getClassName() : "none";
+            String callingParent = cause.length > 3 ? cause[4].getClassName() : "none";
+            // FML is allowed to call system exit and the Minecraft applet (from the quit button), and the dedicated
+            // server (from itself)
+            if (!(callingClass.startsWith("cpw.mods.fml.")
+                || ("net.minecraft.client.Minecraft".equals(callingClass)
+                    && "net.minecraft.client.Minecraft".equals(callingParent))
+                || ("net.minecraft.server.dedicated.DedicatedServer".equals(callingClass)
+                    && "net.minecraft.server.MinecraftServer".equals(callingParent)))) {
+                throw new ExitTrappedException();
+            }
+        }
+    }
+}

--- a/src/forgePatches/java/cpw/mods/fml/common/asm/transformers/TerminalTransformer.java
+++ b/src/forgePatches/java/cpw/mods/fml/common/asm/transformers/TerminalTransformer.java
@@ -32,7 +32,8 @@ public class TerminalTransformer implements IClassTransformer {
         private static final String callbackOwner = org.objectweb.asm.Type.getInternalName(ExitVisitor.class);
 
         private ExitVisitor(ClassVisitor cv) {
-            super(Opcodes.ASM5, cv);
+            // LWJGL3ify patch: ASM5->ASM9
+            super(Opcodes.ASM9, cv);
         }
 
         @Override
@@ -51,7 +52,8 @@ public class TerminalTransformer implements IClassTransformer {
                 || clsName.startsWith("com/jcraft/jogg/")
                 || clsName.startsWith("scala/sys/"));
 
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(mAccess, mName, mDesc, mSignature, mExceptions)) {
+            // LWJGL3ify patch: ASM5->ASM9
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(mAccess, mName, mDesc, mSignature, mExceptions)) {
 
                 @Override
                 public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean isIntf) {

--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Lwjgl3ifyCoremod.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Lwjgl3ifyCoremod.java
@@ -117,6 +117,7 @@ public class Lwjgl3ifyCoremod implements IFMLLoadingPlugin, IEarlyMixinLoader {
         // FML Java 9+ compatibility patches
         mixins.add("fml.ItemStackHolderRef");
         mixins.add("fml.JarDiscoverer");
+        mixins.add("fml.ModVisitorAsmVersion");
         mixins.add("fml.ObjectHolderRef");
         mixins.add("fml.ObjectHolderRegistry");
         if (FMLLaunchHandler.side()

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/fml/ModVisitorAsmVersion.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/fml/ModVisitorAsmVersion.java
@@ -1,0 +1,22 @@
+package me.eigenraven.lwjgl3ify.mixins.fml;
+
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import cpw.mods.fml.common.discovery.asm.ModAnnotationVisitor;
+import cpw.mods.fml.common.discovery.asm.ModClassVisitor;
+import cpw.mods.fml.common.discovery.asm.ModFieldVisitor;
+import cpw.mods.fml.common.discovery.asm.ModMethodVisitor;
+
+@Mixin(
+    value = { ModClassVisitor.class, ModAnnotationVisitor.class, ModFieldVisitor.class, ModMethodVisitor.class },
+    remap = false)
+public class ModVisitorAsmVersion {
+
+    @ModifyConstant(method = "<init>*", constant = @Constant(intValue = Opcodes.ASM5), remap = false)
+    private static int lwjgl3ify$acceptNewerAsm(int original) {
+        return Opcodes.ASM9;
+    }
+}


### PR DESCRIPTION
- Modify all version-restricted ASM transformers inside of forge/FML to accept Java 21 classes, this means mods *can* be compiled with Java 21 if no backwards compatible is desired by someone or for experiments (3rd party coremods can still break)
- Update ASM to 9.5 for Java 21 support inside of forge and FML
- Embed all modified libraries in the forgePatches jar to remove the annoying installation step of merging client libraries into the server installation directory (also simplifies launchwrapper updates, DAXXL no longer needs updating with new library files)
- Update and clarify some minor issues in the README

Tested manually in the dev env, a Prism client instance and a fresh forge server instance - the server installation process is much less error-prone now!