### PR TITLE
Check for GLFW_KEY_UNKNOWN

### DIFF
--- a/src/main/java/org/lwjglx/input/Keyboard.java
+++ b/src/main/java/org/lwjglx/input/Keyboard.java
@@ -1,5 +1,7 @@
 package org.lwjglx.input;
 
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_UNKNOWN;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -260,7 +262,7 @@ public class Keyboard {
             return false;
         }
         final int keyCode = KeyCodes.lwjglToGlfw(key);
-        return GLFW.glfwGetKey(Display.getWindow(), keyCode) == GLFW.GLFW_PRESS;
+        return keyCode != GLFW_KEY_UNKNOWN && GLFW.glfwGetKey(Display.getWindow(), keyCode) == GLFW.GLFW_PRESS;
     }
 
     public static void poll() {


### PR DESCRIPTION
Avoids the following error when running in debug mode:
```
    Description : Invalid key -1
    Stacktrace  :
org.lwjgl.glfw.GLFWErrorCallbackI.callback(GLFWErrorCallbackI.java:43)
org.lwjgl.system.JNI.invokePI(Native Method)
org.lwjgl.glfw.GLFW.glfwGetKey(GLFW.java:3746)
org.lwjglx.debug.$Proxy$4840.glfwGetKey577(Unknown Source)
org.lwjglx.input.Keyboard.isKeyDown(Keyboard.java:263)
net.minecraft.client.settings.KeyBinding.hodgepodge$updateKeyStates(KeyBinding.java:590)
net.minecraft.client.Minecraft.handler$zeb000$hodgepodge$updateKeysStates(Minecraft.java:6596)
net.minecraft.client.Minecraft.setIngameFocus(Minecraft.java:1386)
net.minecraft.client.Minecraft.displayGuiScreen(Minecraft.java:871)
net.minecraft.client.gui.GuiChat.keyTyped(GuiChat.java:119)
```