### PR TITLE
Fix for horizontal scrolling

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
@@ -183,8 +183,11 @@ public class Config {
 
         INPUT_INVERT_WHEEL = config
             .getBoolean("invertScrollWheel", CATEGORY_INPUT, INPUT_INVERT_WHEEL, "Invert scrolling direction");
-        INPUT_INVERT_X_WHEEL = config
-            .getBoolean("invertHorizontalScroll", CATEGORY_INPUT, INPUT_INVERT_X_WHEEL, "Invert horizontal scrolling direction (respects invertScrollWheel)");
+        INPUT_INVERT_X_WHEEL = config.getBoolean(
+            "invertHorizontalScroll",
+            CATEGORY_INPUT,
+            INPUT_INVERT_X_WHEEL,
+            "Invert horizontal scrolling direction (respects invertScrollWheel)");
         INPUT_SCROLL_SPEED = (double) config.getFloat(
             "scrollSpeedMultiplier",
             CATEGORY_INPUT,

--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
@@ -75,6 +75,7 @@ public class Config {
     public static boolean OPENGL_CONTEXT_NO_ERROR = false;
 
     public static boolean INPUT_INVERT_WHEEL = false;
+    public static boolean INPUT_INVERT_X_WHEEL = false;
     public static double INPUT_SCROLL_SPEED = 1.0;
 
     public static String X11_CLASS_NAME = "minecraft";
@@ -182,6 +183,8 @@ public class Config {
 
         INPUT_INVERT_WHEEL = config
             .getBoolean("invertScrollWheel", CATEGORY_INPUT, INPUT_INVERT_WHEEL, "Invert scrolling direction");
+        INPUT_INVERT_X_WHEEL = config
+            .getBoolean("invertHorizontalScroll", CATEGORY_INPUT, INPUT_INVERT_X_WHEEL, "Invert horizontal scrolling direction (respects invertScrollWheel)");
         INPUT_SCROLL_SPEED = (double) config.getFloat(
             "scrollSpeedMultiplier",
             CATEGORY_INPUT,

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -271,7 +271,7 @@ public class Display {
                 if (Config.DEBUG_PRINT_MOUSE_EVENTS) {
                     Lwjgl3ify.LOG.info("[DEBUG-MOUSE] wheel window:{} xoffset:{} yoffset:{}", window, xoffset, yoffset);
                 }
-                Mouse.addWheelEvent(yoffset == 0 ? xoffset : yoffset);
+                Mouse.addWheelEvent(yoffset == 0 ? (Config.INPUT_INVERT_X_WHEEL ? -xoffset : xoffset) : yoffset);
             }
         };
 

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -271,7 +271,7 @@ public class Display {
                 if (Config.DEBUG_PRINT_MOUSE_EVENTS) {
                     Lwjgl3ify.LOG.info("[DEBUG-MOUSE] wheel window:{} xoffset:{} yoffset:{}", window, xoffset, yoffset);
                 }
-                Mouse.addWheelEvent(yoffset);
+                Mouse.addWheelEvent(yoffset == 0 ? xoffset : yoffset);
             }
         };
 


### PR DESCRIPTION
This PR accounts for horizontal scrolling (as opposed to the traditional vertical scrolling), i.e. when holding SHIFT on macOS, to be accounted for by the game by passing `xoffset` (horizontal scroll offset) instead of `yoffset` (vertical scroll offset) to `Mouse#addWheelEvent` when `yoffset` is `0` (and thus not vertical) when initializing `Display$Window#mouseButtonCallback`.

This was a bug in Minecraft ever since it updated to LWJGL 3 officially, until it was fixed in 1.20.2.  
Note that the vanilla game (now) *inverts* horizontal scrolling by default - for example, in my case (on my macOS machine), when scrolling through items in the hotbar, scrolling normally would move the item selector(?) in one direction, while doing so while holding SHIFT would move it in the other.

This does not match the behavior of the few mods that fixed this issue before Mojang did (including [EmuNO](https://github.com/RyanModDev/emuno), [MacOS Input Fixes](https://github.com/hamarb123/MCMacOSInputFixes), and [McMouser](https://github.com/MinecraftMachina/McMouser)), which would scroll in the same direction regardless of whether SHIFT was held.

Because of this discrepancy, this PR also adds a config option to invert horizontal scrolling specifically. Note that it respects / "stacks with" the general "invert scrolling" config option - having both enabled would invert horizontal scrolling *twice,* making it go in the same direction as when both config options are disabled, etc.