### PR TITLE
Disable STB stitching if FC 1.23 is present even with OF

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Lwjgl3ifyCoremod.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Lwjgl3ifyCoremod.java
@@ -1,11 +1,14 @@
 package me.eigenraven.lwjgl3ify.core;
 
 import java.awt.Toolkit;
+import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.minecraft.launchwrapper.Launch;
 import net.minecraft.launchwrapper.LaunchClassLoader;
 
 import org.apache.logging.log4j.LogManager;
@@ -131,10 +134,13 @@ public class Lwjgl3ifyCoremod implements IFMLLoadingPlugin, IEarlyMixinLoader {
                 LOGGER.info("Disabling STB texture loading mixin");
             }
 
-            final boolean fcBugTriggered = hasFastcraft && !hasOptifine;
+            final boolean fcBugFixedByOF = isFastcraftVersion1_25();
+            final boolean fcBugTriggered = hasFastcraft && !(hasOptifine && fcBugFixedByOF);
             if (fcBugTriggered && !Config.MIXIN_STBI_IGNORE_FASTCRAFT) {
                 LOGGER.error(
-                    "Not using STB stiching mixins because FastCraft is installed to prevent rapidly flashing screen. Remove FastCraft or add OptiFine to enable these performance-improving patches.");
+                    "Not using STB stiching mixins because FastCraft is installed to prevent rapidly flashing screen. Remove FastCraft or "
+                        + (!fcBugFixedByOF ? "update to FastCraft 1.25 and " : "")
+                        + "add OptiFine to enable these performance-improving patches.");
             } else {
                 if (Config.MIXIN_STBI_TEXTURE_STICHING) {
                     LOGGER.info("Enabling STB texture stitching mixin");
@@ -145,5 +151,25 @@ public class Lwjgl3ifyCoremod implements IFMLLoadingPlugin, IEarlyMixinLoader {
             }
         }
         return mixins;
+    }
+
+    private static boolean isFastcraftVersion1_25() {
+        // FastCraft tweaker hasn't run yet so no easy way to grab version.
+        // Let's compare the hash of fastcraft.a, which contains the version string in both 1.23 and 1.25.
+        try {
+            byte[] bytes = Launch.classLoader.getClassBytes("fastcraft.a");
+
+            if (bytes == null) return false;
+
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+
+            final byte[] fc125AHash = new byte[] { -125, -16, 44, -79, -105, 108, -65, -19, 56, -98, -65, -94, 0, -49,
+                66, -58, -60, -39, -23, 55, 87, 127, -77, 100, 73, -92, 37, 84, 115, -114, -76, -23 };
+
+            return Arrays.equals(fc125AHash, hash);
+        } catch (Exception e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
In FastCraft 1.23's case, adding OptiFine doesn't fix the flashing issue of the STB mixins. This PR updates the disabling logic to apply in this case as well.

(OptiFine D6 is compatible with Java 9+ if using [OptiFine3ify](https://github.com/makamys/OptiFine3ify).)