### PR TITLE
Remove the need for lwjgl package transformer exclusions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1704135167
+//version: 1704650211
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -53,7 +53,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.26'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.27'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,8 +11,8 @@ def asmVersion = '9.5'
 
 dependencies {
     // Resolve newer versions of LaunchWrapper to allow java 9+ compat
-    vanilla_minecraft('net.minecraft:launchwrapper:1.17.3') { transitive = false }
-    forgePatchesEmbedded('net.minecraft:launchwrapper:1.17.3') { transitive = false }
+    vanilla_minecraft('net.minecraft:launchwrapper:1.17.4') { transitive = false }
+    forgePatchesEmbedded('net.minecraft:launchwrapper:1.17.4') { transitive = false }
 
     forgePatchesEmbedded("org.ow2.asm:asm:${asmVersion}")
     forgePatchesEmbedded("org.ow2.asm:asm-commons:${asmVersion}")

--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Lwjgl3ifyCoremod.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Lwjgl3ifyCoremod.java
@@ -26,7 +26,6 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import me.eigenraven.lwjgl3ify.Tags;
 
 @IFMLLoadingPlugin.MCVersion("1.7.10")
-@IFMLLoadingPlugin.TransformerExclusions({ "org.lwjglx", "org.lwjgl", "org.lwjgl.input", "org.lwjglx.input" })
 @IFMLLoadingPlugin.SortingIndex(Integer.MAX_VALUE - 2)
 public class Lwjgl3ifyCoremod implements IFMLLoadingPlugin, IEarlyMixinLoader {
 

--- a/src/main/java/me/eigenraven/lwjgl3ify/core/LwjglRedirectTransformer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/LwjglRedirectTransformer.java
@@ -41,7 +41,7 @@ public class LwjglRedirectTransformer extends Remapper implements IClassTransfor
             return basicClass;
         }
         for (String prefix : excludedPackages) {
-            if (transformedName.startsWith(prefix.replace('/', '.'))) {
+            if (transformedName.startsWith(prefix)) {
                 return basicClass;
             }
         }


### PR DESCRIPTION
Allows coremods to be more flexible with asm transforms