### PR TITLE
Add Config Toggle to Enable / Disable HRTF Bools in OpenAl

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
@@ -74,6 +74,8 @@ public class Config {
     public static boolean OPENGL_DOUBLEBUFFER = true;
     public static boolean OPENGL_CONTEXT_NO_ERROR = false;
 
+    public static boolean OPENAL_ENABLE_HRTF = false;
+
     public static boolean INPUT_INVERT_WHEEL = false;
     public static boolean INPUT_INVERT_X_WHEEL = false;
     public static double INPUT_SCROLL_SPEED = 1.0;
@@ -91,7 +93,8 @@ public class Config {
     public static final String CATEGORY_DEBUG = "debug";
     public static final String CATEGORY_WINDOW = "window";
     public static final String CATEGORY_INPUT = "input";
-    public static final String CATEGORY_GLCONTEXT = "openglContext";
+    public static final String CATEGORY_GLCONTEXT = "openglcontext";
+    public static final String CATEGORY_OPENALCONTEXT = "openalcontext";
 
     public static Configuration config = null;
 
@@ -228,6 +231,9 @@ public class Config {
             CATEGORY_GLCONTEXT,
             OPENGL_CONTEXT_NO_ERROR,
             "Enable GL_KHR_no_error to use faster driver code, but which can cause memory corruption in case of OpenGL errors");
+
+        OPENAL_ENABLE_HRTF = config
+            .getBoolean("enableHRTF", CATEGORY_OPENALCONTEXT, OPENAL_ENABLE_HRTF, "Enable HRTF sound support");
     }
 
     public static Set<String> getExtensibleEnums() {

--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -1,5 +1,7 @@
 package org.lwjglx.openal;
 
+import static me.eigenraven.lwjgl3ify.core.Config.OPENAL_ENABLE_HRTF;
+
 import java.nio.IntBuffer;
 
 import org.lwjgl.openal.ALC10;
@@ -41,6 +43,17 @@ public class AL {
         attribs.put(org.lwjgl.openal.ALC10.ALC_SYNC);
         attribs.put(contextSynchronized ? org.lwjgl.openal.ALC10.ALC_TRUE : org.lwjgl.openal.ALC10.ALC_FALSE);
 
+        /////////////////////////////////////////////
+        // HRTF
+        if (!OPENAL_ENABLE_HRTF) {
+            attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_SOFT);
+            attribs.put(org.lwjgl.openal.ALC10.ALC_FALSE);
+
+            attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_ID_SOFT);
+            attribs.put(0);
+        }
+        /////////////////////////////////////////////
+
         attribs.put(org.lwjgl.openal.EXTEfx.ALC_MAX_AUXILIARY_SENDS);
         attribs.put(4);
 
@@ -52,14 +65,12 @@ public class AL {
         long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(defaultDevice);
 
         alcDevice = new ALCdevice(deviceHandle);
-
         final ALCCapabilities deviceCaps = org.lwjgl.openal.ALC.createCapabilities(deviceHandle);
 
         long contextHandle = org.lwjgl.openal.ALC10.alcCreateContext(AL.getDevice().device, attribs);
         alcContext = new ALCcontext(contextHandle);
         org.lwjgl.openal.ALC10.alcMakeContextCurrent(contextHandle);
         org.lwjgl.openal.AL.createCapabilities(deviceCaps);
-
         created = true;
     }
 

--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -1,7 +1,5 @@
 package org.lwjglx.openal;
 
-import static me.eigenraven.lwjgl3ify.core.Config.OPENAL_ENABLE_HRTF;
-
 import java.nio.IntBuffer;
 
 import org.lwjgl.openal.ALC10;
@@ -9,6 +7,8 @@ import org.lwjgl.openal.ALCCapabilities;
 import org.lwjglx.BufferUtils;
 import org.lwjglx.LWJGLException;
 import org.lwjglx.Sys;
+
+import me.eigenraven.lwjgl3ify.core.Config;
 
 public class AL {
 
@@ -45,7 +45,7 @@ public class AL {
 
         /////////////////////////////////////////////
         // HRTF
-        if (!OPENAL_ENABLE_HRTF) {
+        if (!Config.OPENAL_ENABLE_HRTF) {
             attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_SOFT);
             attribs.put(org.lwjgl.openal.ALC10.ALC_FALSE);
 


### PR DESCRIPTION
Two toggles are now turned off by default to disable HRTF
Fixed the config to lowercase else it will appear in the config like this:

```
openglContext {
}


openglcontext {
    # Enable KHR_debug in the OpenGL context for advanced debugging capabilities [default: false]
    B:debugContext=false

    # Make the framebuffer double-buffered (will cause visual artifacts if disabled) [default: true]
    B:doubleBuffer=true

    # Enable GL_KHR_no_error to use faster driver code, but which can cause memory corruption in case of OpenGL errors [default: false]
    B:noError=false

    # Make the framebuffer use the sRGB color space [default: false]
    B:srgb=false
}
```