### PR TITLE
Allow access to sun.awt to fix MineTweaker

### DIFF
--- a/java9args.txt
+++ b/java9args.txt
@@ -24,7 +24,7 @@ java.base/sun.nio.ch=ALL-UNNAMED
 --add-opens
 jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming
 --add-opens
-java.desktop/sun.awt.image=ALL-UNNAMED
+java.desktop/sun.awt=ALL-UNNAMED
 --add-opens
 java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED
 --add-modules jdk.dynalink


### PR DESCRIPTION
Allow access to sun.awt package to fix MineTweaker not being able to use clipboard for /mt hand command.

Tried to find a more specific package, but required class is a part of the core awt package.

Questionable PR in terms of security, so feel free to discuss.