### PR TITLE
Make Sys.getClipboard() static.

### DIFF
--- a/src/main/java/org/lwjglx/Sys.java
+++ b/src/main/java/org/lwjglx/Sys.java
@@ -87,7 +87,7 @@ public class Sys {
             .endsWith("64");
     }
 
-    public String getClipboard() {
+    public static String getClipboard() {
         return GLFW.glfwGetClipboardString(Display.getWindow());
     }
 }


### PR DESCRIPTION
The Sys.getClipboard() method must be static
Original source: https://github.com/LWJGL/lwjgl/blob/master/src/java/org/lwjgl/Sys.java#L269