### PR TITLE
Fix scaling on HiDPI screens with Wayland

### DIFF
--- a/src/main/java/org/lwjglx/input/Mouse.java
+++ b/src/main/java/org/lwjglx/input/Mouse.java
@@ -53,6 +53,10 @@ public class Mouse {
             ignoreNextMove--;
             return;
         }
+        float scale = Display.getPixelScaleFactor();
+        // convert from screen-space coordinates to framebuffer coordinates
+        mouseX *= scale;
+        mouseY *= scale;
         dx += (int) mouseX - latestX;
         dy += Display.getHeight() - (int) mouseY - latestY;
         latestX = (int) mouseX;
@@ -279,7 +283,13 @@ public class Mouse {
         if (grabbed) {
             return;
         }
-        GLFW.glfwSetCursorPos(Display.getWindow(), new_x, new_y);
+        // convert back from framebuffer coordinates to screen-space coordinates
+        float inv_scale = 1.0f / Display.getPixelScaleFactor();
+        new_x *= inv_scale;
+        new_y *= inv_scale;
+        GLFW.glfwSetCursorPos(Display.getWindow(), new_x * inv_scale, new_y * inv_scale);
+        // this might lose accuracy, since we just went from fb->screen and this will
+        // undo that change. Yay floating point numbers!
         addMoveEvent(new_x, new_y);
     }
 

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -895,8 +895,8 @@ public class Display {
         // framebuffer size and window size always map 1:1
         glfwGetWindowSize(getWindow(), windowWidth, windowHeight);
         glfwGetFramebufferSize(getWindow(), framebufferWidth, framebufferHeight);
-        xScale = (float)framebufferWidth[0]/windowWidth[0];
-        yScale = (float)framebufferHeight[0]/windowHeight[0];
+        xScale = (float) framebufferWidth[0] / windowWidth[0];
+        yScale = (float) framebufferHeight[0] / windowHeight[0];
         return Math.max(xScale, yScale);
     }
 

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -195,9 +195,6 @@ public class Display {
         glfwWindowHintString(GLFW_X11_CLASS_NAME, Config.X11_CLASS_NAME);
         glfwWindowHintString(GLFW_COCOA_FRAME_NAME, Config.COCOA_FRAME_NAME);
 
-        // request a non-hidpi framebuffer on Retina displays on MacOS
-        if (glfwGetPlatform() == GLFW_PLATFORM_COCOA) glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
-
         if (Config.WINDOW_CENTERED) {
             glfwWindowHint(GLFW_POSITION_X, (monitorWidth - mode.getWidth()) / 2);
             glfwWindowHint(GLFW_POSITION_Y, (monitorHeight - mode.getHeight()) / 2);
@@ -887,10 +884,20 @@ public class Display {
         if (!isCreated()) {
             return 1.0f;
         }
-        float[] xScale = new float[1];
-        float[] yScale = new float[1];
-        glfwGetWindowContentScale(getWindow(), xScale, yScale);
-        return Math.max(xScale[0], yScale[0]);
+        int[] windowWidth = new int[1];
+        int[] windowHeight = new int[1];
+        int[] framebufferWidth = new int[1];
+        int[] framebufferHeight = new int[1];
+        float xScale, yScale;
+        // via technicality we actually have to divide the framebuffer
+        // size by the window size here, since glfwGetWindowContentScale
+        // returns a value not equal to 1 even on platforms where the
+        // framebuffer size and window size always map 1:1
+        glfwGetWindowSize(getWindow(), windowWidth, windowHeight);
+        glfwGetFramebufferSize(getWindow(), framebufferWidth, framebufferHeight);
+        xScale = (float)framebufferWidth[0]/windowWidth[0];
+        yScale = (float)framebufferHeight[0]/windowHeight[0];
+        return Math.max(xScale, yScale);
     }
 
     public static void setSwapInterval(int value) {

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -195,8 +195,8 @@ public class Display {
         glfwWindowHintString(GLFW_X11_CLASS_NAME, Config.X11_CLASS_NAME);
         glfwWindowHintString(GLFW_COCOA_FRAME_NAME, Config.COCOA_FRAME_NAME);
 
-        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE); // request a non-hidpi framebuffer on Retina displays
-        // on MacOS
+        // request a non-hidpi framebuffer on Retina displays on MacOS
+        // glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
 
         if (Config.WINDOW_CENTERED) {
             glfwWindowHint(GLFW_POSITION_X, (monitorWidth - mode.getWidth()) / 2);
@@ -607,19 +607,14 @@ public class Display {
         return displayY;
     }
 
+    // vanilla and forge both expect these to return the framebuffer width
+    // rather than the window width, and they both call glViewport with the
+    // result
     public static int getWidth() {
-        return displayWidth;
-    }
-
-    public static int getHeight() {
-        return displayHeight;
-    }
-
-    public static int getFramebufferWidth() {
         return displayFramebufferWidth;
     }
 
-    public static int getFramebufferHeight() {
+    public static int getHeight() {
         return displayFramebufferHeight;
     }
 

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -196,7 +196,7 @@ public class Display {
         glfwWindowHintString(GLFW_COCOA_FRAME_NAME, Config.COCOA_FRAME_NAME);
 
         // request a non-hidpi framebuffer on Retina displays on MacOS
-        // glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
+        if (glfwGetPlatform() == GLFW_PLATFORM_COCOA) glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
 
         if (Config.WINDOW_CENTERED) {
             glfwWindowHint(GLFW_POSITION_X, (monitorWidth - mode.getWidth()) / 2);


### PR DESCRIPTION
The game expects `getWidth` and `getHeight` to return framebuffer coordinates rather than screen-space coordinates (as shown by the calls to `glViewport`). This was broken on scaling factors greater than 1 but also masked by `GL_SCALE_FRAMEBUFFER`.

Additionally, the game's mouse code *also* expects framebuffer coordinates to be returned. This fixes that by converting to and from screen-space during calls to mouse code.

Disable `GLFW_COCOA_RETINA_FRAMEBUFFER` for now, it seems to not play nice on non-MacOS systems. At least for me it makes the title screen much larger than the window when playing in fullscreen.

Screenshot before the change:
![image](https://github.com/user-attachments/assets/7bbcc008-faca-4a30-85e8-99a94ae6d8ec)


Screenshot after the change:
![image](https://github.com/user-attachments/assets/fc220e86-8468-4e54-b859-5d12c0592c12)

Before is marginally fuzzier (and obviously doesn't work with the title screen)