### PR TITLE
Fix SoundManager handling when no sound devices exist

### DIFF
--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -26,12 +26,12 @@ public class AL {
     }
 
     public static void create(String deviceArguments, int contextFrequency, int contextRefresh,
-        boolean contextSynchronized) {
+        boolean contextSynchronized) throws LWJGLException {
         create(deviceArguments, contextFrequency, contextRefresh, contextSynchronized, true);
     }
 
     public static void create(String deviceArguments, int contextFrequency, int contextRefresh,
-        boolean contextSynchronized, boolean openDevice) {
+        boolean contextSynchronized, boolean openDevice) throws LWJGLException {
         IntBuffer attribs = BufferUtils.createIntBuffer(16);
 
         attribs.put(org.lwjgl.openal.ALC10.ALC_FREQUENCY);
@@ -63,6 +63,10 @@ public class AL {
         String defaultDevice = org.lwjgl.openal.ALC10.alcGetString(0, ALC10.ALC_DEFAULT_DEVICE_SPECIFIER);
 
         long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(defaultDevice);
+
+        if (deviceHandle == 0) {
+            throw new LWJGLException("Could not open ALC device");
+        }
 
         alcDevice = new ALCdevice(deviceHandle);
         final ALCCapabilities deviceCaps = org.lwjgl.openal.ALC.createCapabilities(deviceHandle);


### PR DESCRIPTION
Supersedes GTNewHorizons/Hodgepodge#420 as a fix for the SoundManager NPE crashes

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17190
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17190
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16281
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12848
Fixes https://github.com/GTNewHorizons/Hodgepodge/issues/406

Adds null check that is present in LWJGL2 when initializing OpenAL sound.