### PR TITLE
Bump ASM to support Java 24

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ minecraft {
 def addGtForTesting = Boolean.parseBoolean(project.getProperties().getOrDefault("withGregtech", "false").toString())
 def addReikaModsForTesting = Boolean.parseBoolean(project.getProperties().getOrDefault("withReikaMods", "false").toString())
 
-def asmVersion = '9.7'
+def asmVersion = '9.7.1'
 def rfbVersion = '1.0.7'
 // 100% binary compatible, 1 minor source compatibility issue (removed a throws IOException clause)
 def gsonVersion = '2.10.1'

--- a/prism-libraries/patches/net.minecraft.json
+++ b/prism-libraries/patches/net.minecraft.json
@@ -12,7 +12,9 @@
         19,
         20,
         21,
-        22
+        22,
+        23,
+        24
     ],
     "formatVersion": 1,
     "libraries": [


### PR DESCRIPTION
Tested in a modified nightly 559. Unimixins has been bumped, but I'm unsure where in the buildscript Unimixins is pulled in