### PR TITLE
java 8 support, huge fps bump, cuz java 17 is utter trash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val taskGroup = "lwjgl3ify"
 
 val newJavaToolchainSpec: JavaToolchainSpec.() -> Unit = {
     vendor = JvmVendorSpec.AZUL
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(11)
 }
 
 val addOpens = listOf(
@@ -108,17 +108,11 @@ sourceSets {
     }
 }
 
-tasks.named<JavaCompile>(hotswapSet.compileJavaTaskName).configure {
+tasks.withType<JavaCompile>(){
     javaCompiler = javaToolchains.compilerFor(newJavaToolchainSpec)
-    sourceCompatibility = JavaVersion.VERSION_17.majorVersion
-    targetCompatibility = JavaVersion.VERSION_17.majorVersion
-}
-
-tasks.named<JavaCompile>(relauncherStubSet.compileJavaTaskName).configure {
-    javaCompiler = javaToolchains.compilerFor(newJavaToolchainSpec)
-    sourceCompatibility = JavaVersion.VERSION_17.majorVersion
-    targetCompatibility = JavaVersion.VERSION_17.majorVersion
-    options.release = 17
+    sourceCompatibility = JavaVersion.VERSION_1_8.majorVersion
+    targetCompatibility = JavaVersion.VERSION_1_8.majorVersion
+    options.release = 8
 }
 
 tasks.createMcLauncherFiles {
@@ -299,7 +293,7 @@ runComparisonTool.configure {
 
 val veryNewJavaToolchainSpec: JavaToolchainSpec.() -> Unit = {
     vendor = JvmVendorSpec.AZUL
-    languageVersion = JavaLanguageVersion.of(21)
+    languageVersion = JavaLanguageVersion.of(8)
 }
 
 val newJavaLauncher = javaToolchains.launcherFor(veryNewJavaToolchainSpec)

--- a/src/generated/java/org/lwjglx/opengl/KHRDebugCallback.java
+++ b/src/generated/java/org/lwjglx/opengl/KHRDebugCallback.java
@@ -48,35 +48,78 @@ public class KHRDebugCallback extends org.lwjglx.PointerWrapperAbstract implemen
                 System.err.println("[LWJGL] KHR_debug message");
                 System.err.println("\tID: " + id);
 
-                String description = switch (source) {
-                    case GL_DEBUG_SOURCE_API -> "API";
-                    case GL_DEBUG_SOURCE_WINDOW_SYSTEM -> "WINDOW SYSTEM";
-                    case GL_DEBUG_SOURCE_SHADER_COMPILER -> "SHADER COMPILER";
-                    case GL_DEBUG_SOURCE_THIRD_PARTY -> "THIRD PARTY";
-                    case GL_DEBUG_SOURCE_APPLICATION -> "APPLICATION";
-                    case GL_DEBUG_SOURCE_OTHER -> "OTHER";
-                    default -> printUnknownToken(source);
+                String description = null;
+                switch (source) {
+                    case GL_DEBUG_SOURCE_API:
+                        description = "API";
+                        break;
+                    case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
+                        description = "WINDOW SYSTEM";
+                        break;
+                    case GL_DEBUG_SOURCE_SHADER_COMPILER:
+                        description = "SHADER COMPILER";
+                        break;
+                    case GL_DEBUG_SOURCE_THIRD_PARTY:
+                        description = "THIRD PARTY";
+                        break;
+                    case GL_DEBUG_SOURCE_APPLICATION:
+                        description = "APPLICATION";
+                        break;
+                    case GL_DEBUG_SOURCE_OTHER:
+                        description = "OTHER";
+                        break;
+                    default:
+                        description = printUnknownToken(source);
+                        break;
                 };
                 System.err.println("\tSource: " + description);
 
-                description = switch (type) {
-                    case GL_DEBUG_TYPE_ERROR -> "ERROR";
-                    case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR -> "DEPRECATED BEHAVIOR";
-                    case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR -> "UNDEFINED BEHAVIOR";
-                    case GL_DEBUG_TYPE_PORTABILITY -> "PORTABILITY";
-                    case GL_DEBUG_TYPE_PERFORMANCE -> "PERFORMANCE";
-                    case GL_DEBUG_TYPE_OTHER -> "OTHER";
-                    case GL_DEBUG_TYPE_MARKER -> "MARKER";
-                    default -> printUnknownToken(type);
+                description = null;
+                switch (type) {
+                    case GL_DEBUG_TYPE_ERROR:
+                        description = "ERROR";
+                        break;
+                    case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
+                        description = "DEPRECATED BEHAVIOR";
+                        break;
+                    case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
+                        description = "UNDEFINED BEHAVIOR";
+                        break;
+                    case GL_DEBUG_TYPE_PORTABILITY:
+                        description = "PORTABILITY";
+                        break;
+                    case GL_DEBUG_TYPE_PERFORMANCE:
+                        description = "PERFORMANCE";
+                        break;
+                    case GL_DEBUG_TYPE_OTHER:
+                        description = "OTHER";
+                        break;
+                    case GL_DEBUG_TYPE_MARKER:
+                        description = "MARKER";
+                        break;
+                    default:
+                        description = printUnknownToken(type);
+                        break;
                 };
                 System.err.println("\tType: " + description);
 
-                description = switch (severity) {
-                    case GL_DEBUG_SEVERITY_HIGH -> "HIGH";
-                    case GL_DEBUG_SEVERITY_MEDIUM -> "MEDIUM";
-                    case GL_DEBUG_SEVERITY_LOW -> "LOW";
-                    case GL_DEBUG_SEVERITY_NOTIFICATION -> "NOTIFICATION";
-                    default -> printUnknownToken(severity);
+                description = null;
+                switch (severity) {
+                    case GL_DEBUG_SEVERITY_HIGH:
+                        description = "HIGH";
+                        break;
+                    case GL_DEBUG_SEVERITY_MEDIUM:
+                        description = "MEDIUM";
+                        break;
+                    case GL_DEBUG_SEVERITY_LOW:
+                        description = "LOW";
+                        break;
+                    case GL_DEBUG_SEVERITY_NOTIFICATION:
+                        description = "NOTIFICATION";
+                        break;
+                    default:
+                        description = printUnknownToken(severity);
+                        break;
                 };
                 System.err.println("\tSeverity: " + description);
 

--- a/src/main/java/me/eigenraven/lwjgl3ify/client/GLDebugLog.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/client/GLDebugLog.java
@@ -66,38 +66,58 @@ public class GLDebugLog {
     }
 
     private static String getDebugSource(int source) {
-        return switch (source) {
-            case GL43.GL_DEBUG_SOURCE_API -> "API";
-            case GL43.GL_DEBUG_SOURCE_WINDOW_SYSTEM -> "WINDOW SYSTEM";
-            case GL43.GL_DEBUG_SOURCE_SHADER_COMPILER -> "SHADER COMPILER";
-            case GL43.GL_DEBUG_SOURCE_THIRD_PARTY -> "THIRD PARTY";
-            case GL43.GL_DEBUG_SOURCE_APPLICATION -> "APPLICATION";
-            case GL43.GL_DEBUG_SOURCE_OTHER -> "OTHER";
-            default -> String.format("Unknown [0x%X]", source);
-        };
+        switch (source) {
+            case GL43.GL_DEBUG_SOURCE_API:
+                return "API";
+            case GL43.GL_DEBUG_SOURCE_WINDOW_SYSTEM:
+                return "WINDOW SYSTEM";
+            case GL43.GL_DEBUG_SOURCE_SHADER_COMPILER:
+                return "SHADER COMPILER";
+            case GL43.GL_DEBUG_SOURCE_THIRD_PARTY:
+                return "THIRD PARTY";
+            case GL43.GL_DEBUG_SOURCE_APPLICATION:
+                return "APPLICATION";
+            case GL43.GL_DEBUG_SOURCE_OTHER:
+                return "OTHER";
+            default:
+                return String.format("Unknown [0x%X]", source);
+        }
     }
 
     private static String getDebugType(int type) {
-        return switch (type) {
-            case GL43.GL_DEBUG_TYPE_ERROR -> "ERROR";
-            case GL43.GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR -> "DEPRECATED BEHAVIOR";
-            case GL43.GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR -> "UNDEFINED BEHAVIOR";
-            case GL43.GL_DEBUG_TYPE_PORTABILITY -> "PORTABILITY";
-            case GL43.GL_DEBUG_TYPE_PERFORMANCE -> "PERFORMANCE";
-            case GL43.GL_DEBUG_TYPE_OTHER -> "OTHER";
-            case GL43.GL_DEBUG_TYPE_MARKER -> "MARKER";
-            default -> String.format("Unknown [0x%X]", type);
-        };
+        switch (type) {
+            case GL43.GL_DEBUG_TYPE_ERROR:
+                return "ERROR";
+            case GL43.GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
+                return "DEPRECATED BEHAVIOR";
+            case GL43.GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
+                return "UNDEFINED BEHAVIOR";
+            case GL43.GL_DEBUG_TYPE_PORTABILITY:
+                return "PORTABILITY";
+            case GL43.GL_DEBUG_TYPE_PERFORMANCE:
+                return "PERFORMANCE";
+            case GL43.GL_DEBUG_TYPE_OTHER:
+                return "OTHER";
+            case GL43.GL_DEBUG_TYPE_MARKER:
+                return "MARKER";
+            default:
+                return String.format("Unknown [0x%X]", type);
+        }
     }
 
     private static String getDebugSeverity(int severity) {
-        return switch (severity) {
-            case GL43.GL_DEBUG_SEVERITY_NOTIFICATION -> "NOTIFICATION";
-            case GL43.GL_DEBUG_SEVERITY_HIGH -> "HIGH";
-            case GL43.GL_DEBUG_SEVERITY_MEDIUM -> "MEDIUM";
-            case GL43.GL_DEBUG_SEVERITY_LOW -> "LOW";
-            default -> String.format("Unknown [0x%X]", severity);
-        };
+        switch (severity) {
+            case GL43.GL_DEBUG_SEVERITY_NOTIFICATION:
+                return "NOTIFICATION";
+            case GL43.GL_DEBUG_SEVERITY_HIGH:
+                return "HIGH";
+            case GL43.GL_DEBUG_SEVERITY_MEDIUM:
+                return "MEDIUM";
+            case GL43.GL_DEBUG_SEVERITY_LOW:
+                return "LOW";
+            default:
+                return String.format("Unknown [0x%X]", severity);
+        }
     }
 
     public static void setupDebugMessageCallback() {

--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Downloader.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Downloader.java
@@ -276,9 +276,14 @@ public class Downloader {
                     final String elAction = elRule.get("action")
                         .getAsString();
                     switch (elAction) {
-                        case "allow" -> allowed = true;
-                        case "disallow" -> allowed = false;
-                        default -> throw new IllegalStateException("Illegal rule action: " + elAction);
+                        case "allow":
+                            allowed = true;
+                            break;
+                        case "disallow":
+                            allowed = false;
+                            break;
+                        default:
+                            throw new IllegalStateException("Illegal rule action: " + elAction);
                     }
                 }
             }
@@ -384,7 +389,7 @@ public class Downloader {
         public boolean equals(Object obj) {
             if (obj == this) return true;
             if (obj == null || obj.getClass() != this.getClass()) return false;
-            var that = (DownloadTask) obj;
+            DownloadTask that = (DownloadTask) obj;
             return Objects.equals(this.sourceUrl, that.sourceUrl) && Arrays.equals(this.checksum, that.checksum)
                 && Objects.equals(this.targetLocation, that.targetLocation);
         }

--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Lwjgl3ifyRelauncherTweaker.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Lwjgl3ifyRelauncherTweaker.java
@@ -79,11 +79,7 @@ public class Lwjgl3ifyRelauncherTweaker implements ITweaker {
             cmmAddCoremod.invoke(null, Launch.classLoader, "me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod", myFile);
             coremodInjected = true;
         } catch (InvocationTargetException e) {
-            if (e.getCause() instanceof RuntimeException re) {
-                throw re;
-            } else {
-                throw new RuntimeException(e);
-            }
+            throw new RuntimeException(e);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Relauncher.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Relauncher.java
@@ -1,6 +1,7 @@
 package me.eigenraven.lwjgl3ify.relauncher;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -236,6 +237,33 @@ public class Relauncher {
                 .collect(Collectors.toList()),
             StandardCharsets.UTF_8);
 
+        File file = argFile.toFile();
+        FileInputStream fis = new FileInputStream(file);
+        byte[] b = new byte[1024];
+        StringBuilder sb = new StringBuilder();
+        int r = 0;
+        while ((r = fis.read(b)) != -1) {
+            sb.append(new String(Arrays.copyOf(b, r)));
+        }
+        String[] lines = sb.toString().split("\\r?\\n");
+        ArrayList<String> arr = new ArrayList<String>();
+        //arr.add(javaBinary);
+        for (String line : lines) {
+            String line2 = line.substring(1);
+            line2 = line2.substring(0, line2.length() - 1);
+            //if (line.contains("-Dfile.encoding=UTF-8")) continue;
+            if (line.contains("--add-opens")) continue;
+            if (line.contains("java.base/")) continue;
+            if (line.contains("java.desktop/")) continue;
+            if (line.contains("java.sql.rowset/")) continue;
+            if (line.contains("jdk.dynalink/")) continue;
+            if (line.contains("jdk.naming.dns/")) continue;
+            if (line.contains("-Djava.security.manager=allow")) continue;
+            //sb2.append(line2 + " ");
+            System.out.println(line2);
+            arr.add(line2);
+        }
+
         final List<String> bootstrapCmd = new ArrayList<>();
         final String[] javas = RelauncherConfig.config.javaInstallationsCache;
         final int javaIdx = RelauncherConfig.config.javaInstallation;
@@ -247,7 +275,9 @@ public class Relauncher {
         }
         bootstrapCmd.add(javaPath);
         if (RelauncherConfig.config.forwardLogs) {
-            bootstrapCmd.add("@" + argFile);
+            for (String arg : arr.toArray(new String[0])) {
+                bootstrapCmd.add(arg);
+            }
         } else {
             bootstrapCmd.add("-Xms16M");
             bootstrapCmd.add("-Xmx256M");

--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/RelauncherUserInterface.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/RelauncherUserInterface.java
@@ -202,7 +202,7 @@ public class RelauncherUserInterface {
 
             // Update labels
             contents.labelMinJavaVer
-                .setText(String.format(contents.translations.getString(TranslationsBundle.KEY_MIN_MOD_JAVA), 17));
+                .setText(String.format(contents.translations.getString(TranslationsBundle.KEY_MIN_MOD_JAVA), 8));
 
             // Set settings values
             final RelauncherConfig.ConfigObject initCfg = RelauncherConfig.config;

--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/SettingsDialog.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/SettingsDialog.java
@@ -69,7 +69,7 @@ public class SettingsDialog {
         buttonAddJava.setText(translations.getString(TranslationsBundle.KEY_ADD_JAVA));
         buttonRun.setText(translations.getString(TranslationsBundle.KEY_RUN_GAME));
         lblJavaExecutable.setText(translations.getString(TranslationsBundle.KEY_JAVA_EXECUTABLE));
-        labelMinJavaVer.setText(String.format(translations.getString(TranslationsBundle.KEY_MIN_MOD_JAVA), 17));
+        labelMinJavaVer.setText(String.format(translations.getString(TranslationsBundle.KEY_MIN_MOD_JAVA), 8));
         tabbedPane1.setTitleAt(0, translations.getString(TranslationsBundle.KEY_TAB_BASIC));
         tabbedPane1.setTitleAt(1, translations.getString(TranslationsBundle.KEY_TAB_ADVANCED));
         lblMinMemory.setText(translations.getString(TranslationsBundle.KEY_MIN_MEMORY_MB));

--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/ForgePatchTransformer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/ForgePatchTransformer.java
@@ -61,10 +61,18 @@ public class ForgePatchTransformer implements RfbClassTransformer {
             return;
         }
         switch (className) {
-            case CLASS_PATCH_MANAGER -> tfClassPatchManager(classNode);
-            case TRACING_PRINT_STREAM -> tfTracingPrintStream(classNode);
-            case FML_SECURITY_MANAGER -> tfFmlSecurityManager(classNode);
-            case ENUM_HELPER -> tfEnumHelper(classNode);
+            case CLASS_PATCH_MANAGER:
+                tfClassPatchManager(classNode);
+                break;
+            case TRACING_PRINT_STREAM:
+                tfTracingPrintStream(classNode);
+                break;
+            case FML_SECURITY_MANAGER:
+                tfFmlSecurityManager(classNode);
+                break;
+            case ENUM_HELPER:
+                tfEnumHelper(classNode);
+                break;
         }
     }
 
@@ -87,20 +95,20 @@ public class ForgePatchTransformer implements RfbClassTransformer {
                 if (insn.getOpcode() != INVOKEVIRTUAL) {
                     continue;
                 }
-                if (!(insn instanceof MethodInsnNode minsn)) {
+                if (!(insn instanceof MethodInsnNode)) {
                     continue;
                 }
-                if (!"java/util/jar/JarInputStream".equals(minsn.owner)) {
+                if (!"java/util/jar/JarInputStream".equals(((MethodInsnNode) insn).owner)) {
                     continue;
                 }
-                if (!"getNextJarEntry".equals(minsn.name)) {
+                if (!"getNextJarEntry".equals(((MethodInsnNode) insn).name)) {
                     continue;
                 }
                 // redirect
-                minsn.setOpcode(INVOKESTATIC);
-                minsn.owner = "me/eigenraven/lwjgl3ify/redirects/JarInputStream";
-                minsn.name = "getNextJarEntrySafe";
-                minsn.desc = "(Ljava/util/jar/JarInputStream;)Ljava/util/jar/JarEntry;";
+                ((MethodInsnNode) insn).setOpcode(INVOKESTATIC);
+                ((MethodInsnNode) insn).owner = "me/eigenraven/lwjgl3ify/redirects/JarInputStream";
+                ((MethodInsnNode) insn).name = "getNextJarEntrySafe";
+                ((MethodInsnNode) insn).desc = "(Ljava/util/jar/JarInputStream;)Ljava/util/jar/JarEntry;";
             }
         }
     }
@@ -126,37 +134,53 @@ public class ForgePatchTransformer implements RfbClassTransformer {
     }
 
     private static Integer tryIconst(AbstractInsnNode i) {
-        return switch (i.getOpcode()) {
-            case ICONST_0 -> 0;
-            case ICONST_1 -> 1;
-            case ICONST_2 -> 2;
-            case ICONST_3 -> 3;
-            case ICONST_4 -> 4;
-            case ICONST_5 -> 5;
-            case ICONST_M1 -> -1;
-            case LDC -> {
+        switch (i.getOpcode()) {
+            case ICONST_0:
+                return 0;
+            case ICONST_1:
+                return 1;
+            case ICONST_2:
+                return 2;
+            case ICONST_3:
+                return 3;
+            case ICONST_4:
+                return 4;
+            case ICONST_5:
+                return 5;
+            case ICONST_M1:
+                return -1;
+            case LDC: {
                 final Object cst = ((LdcInsnNode) i).cst;
                 if (cst instanceof Integer) {
-                    yield (Integer) cst;
+                    return (Integer) cst;
                 } else {
-                    yield null;
+                    return null;
                 }
             }
-            default -> null;
-        };
+            default:
+                return null;
+        }
     }
 
     private static AbstractInsnNode makeIconst(int i) {
-        return switch (i) {
-            case 0 -> new InsnNode(ICONST_0);
-            case 1 -> new InsnNode(ICONST_1);
-            case 2 -> new InsnNode(ICONST_2);
-            case 3 -> new InsnNode(ICONST_3);
-            case 4 -> new InsnNode(ICONST_4);
-            case 5 -> new InsnNode(ICONST_5);
-            case -1 -> new InsnNode(ICONST_M1);
-            default -> new LdcInsnNode(i);
-        };
+        switch (i) {
+            case 0:
+                return new InsnNode(ICONST_0);
+            case 1:
+                return new InsnNode(ICONST_1);
+            case 2:
+                return new InsnNode(ICONST_2);
+            case 3:
+                return new InsnNode(ICONST_3);
+            case 4:
+                return new InsnNode(ICONST_4);
+            case 5:
+                return new InsnNode(ICONST_5);
+            case -1:
+                return new InsnNode(ICONST_M1);
+            default:
+                return new LdcInsnNode(i);
+        }
     }
 
     private void tfFmlSecurityManager(@NotNull ClassNodeHandle handle) {

--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
@@ -60,8 +60,8 @@ public class LwjglRedirectTransformer extends Remapper implements RfbClassTransf
 
     @Override
     public void onRegistration(@NotNull ExtensibleClassLoader classLoader) {
-        if (classLoader instanceof LaunchClassLoader lcl) {
-            lcl.addClassLoaderExclusion("me.eigenraven.lwjgl3ify.pack200.");
+        if (classLoader instanceof LaunchClassLoader) {
+            ((LaunchClassLoader) classLoader).addClassLoaderExclusion("me.eigenraven.lwjgl3ify.pack200.");
         }
     }
 

--- a/src/main/java/org/lwjglx/LWJGLUtil.java
+++ b/src/main/java/org/lwjglx/LWJGLUtil.java
@@ -260,10 +260,17 @@ public class LWJGLUtil {
 
     static {
         switch (Platform.get()) {
-            case WINDOWS -> PLATFORM = PLATFORM_WINDOWS;
-            case LINUX -> PLATFORM = PLATFORM_LINUX;
-            case MACOSX -> PLATFORM = PLATFORM_MACOSX;
-            default -> throw new LinkageError("Unknown platform: " + Platform.get());
+            case WINDOWS:
+                PLATFORM = PLATFORM_WINDOWS;
+                break;
+            case LINUX:
+                PLATFORM = PLATFORM_LINUX;
+                break;
+            case MACOSX:
+                PLATFORM = PLATFORM_MACOSX;
+                break;
+            default:
+                throw new LinkageError("Unknown platform: " + Platform.get());
         }
     }
 
@@ -293,12 +300,16 @@ public class LWJGLUtil {
      * @return current platform name
      */
     public static String getPlatformName() {
-        return switch (LWJGLUtil.getPlatform()) {
-            case LWJGLUtil.PLATFORM_LINUX -> PLATFORM_LINUX_NAME;
-            case LWJGLUtil.PLATFORM_MACOSX -> PLATFORM_MACOSX_NAME;
-            case LWJGLUtil.PLATFORM_WINDOWS -> PLATFORM_WINDOWS_NAME;
-            default -> "unknown";
-        };
+        switch (LWJGLUtil.getPlatform()) {
+            case LWJGLUtil.PLATFORM_LINUX:
+                return PLATFORM_LINUX_NAME;
+            case LWJGLUtil.PLATFORM_MACOSX:
+                return PLATFORM_MACOSX_NAME;
+            case LWJGLUtil.PLATFORM_WINDOWS:
+                return PLATFORM_WINDOWS_NAME;
+            default:
+                return "unknown";
+        }
     }
 
     /**

--- a/src/main/java/org/lwjglx/input/KeyCodes.java
+++ b/src/main/java/org/lwjglx/input/KeyCodes.java
@@ -10,121 +10,234 @@ public class KeyCodes {
         if (glfwKeyCode > GLFW.GLFW_KEY_LAST) {
             return glfwKeyCode;
         }
-        return switch (glfwKeyCode) {
-            case GLFW.GLFW_KEY_UNKNOWN -> Keyboard.KEY_UNLABELED; // arbitrary mapping to fix text input here
-            case GLFW.GLFW_KEY_ESCAPE -> Keyboard.KEY_ESCAPE;
-            case GLFW.GLFW_KEY_BACKSPACE -> Keyboard.KEY_BACK;
-            case GLFW.GLFW_KEY_TAB -> Keyboard.KEY_TAB;
-            case GLFW.GLFW_KEY_ENTER -> Keyboard.KEY_RETURN;
-            case GLFW.GLFW_KEY_SPACE -> Keyboard.KEY_SPACE;
-            case GLFW.GLFW_KEY_LEFT_CONTROL -> Keyboard.KEY_LCONTROL;
-            case GLFW.GLFW_KEY_LEFT_SHIFT -> Keyboard.KEY_LSHIFT;
-            case GLFW.GLFW_KEY_LEFT_ALT -> Keyboard.KEY_LMENU;
-            case GLFW.GLFW_KEY_LEFT_SUPER -> Keyboard.KEY_LMETA;
-            case GLFW.GLFW_KEY_RIGHT_CONTROL -> Keyboard.KEY_RCONTROL;
-            case GLFW.GLFW_KEY_RIGHT_SHIFT -> Keyboard.KEY_RSHIFT;
-            case GLFW.GLFW_KEY_RIGHT_ALT -> Keyboard.KEY_RMENU;
-            case GLFW.GLFW_KEY_RIGHT_SUPER -> Keyboard.KEY_RMETA;
-            case GLFW.GLFW_KEY_1 -> Keyboard.KEY_1;
-            case GLFW.GLFW_KEY_2 -> Keyboard.KEY_2;
-            case GLFW.GLFW_KEY_3 -> Keyboard.KEY_3;
-            case GLFW.GLFW_KEY_4 -> Keyboard.KEY_4;
-            case GLFW.GLFW_KEY_5 -> Keyboard.KEY_5;
-            case GLFW.GLFW_KEY_6 -> Keyboard.KEY_6;
-            case GLFW.GLFW_KEY_7 -> Keyboard.KEY_7;
-            case GLFW.GLFW_KEY_8 -> Keyboard.KEY_8;
-            case GLFW.GLFW_KEY_9 -> Keyboard.KEY_9;
-            case GLFW.GLFW_KEY_0 -> Keyboard.KEY_0;
-            case GLFW.GLFW_KEY_A -> Keyboard.KEY_A;
-            case GLFW.GLFW_KEY_B -> Keyboard.KEY_B;
-            case GLFW.GLFW_KEY_C -> Keyboard.KEY_C;
-            case GLFW.GLFW_KEY_D -> Keyboard.KEY_D;
-            case GLFW.GLFW_KEY_E -> Keyboard.KEY_E;
-            case GLFW.GLFW_KEY_F -> Keyboard.KEY_F;
-            case GLFW.GLFW_KEY_G -> Keyboard.KEY_G;
-            case GLFW.GLFW_KEY_H -> Keyboard.KEY_H;
-            case GLFW.GLFW_KEY_I -> Keyboard.KEY_I;
-            case GLFW.GLFW_KEY_J -> Keyboard.KEY_J;
-            case GLFW.GLFW_KEY_K -> Keyboard.KEY_K;
-            case GLFW.GLFW_KEY_L -> Keyboard.KEY_L;
-            case GLFW.GLFW_KEY_M -> Keyboard.KEY_M;
-            case GLFW.GLFW_KEY_N -> Keyboard.KEY_N;
-            case GLFW.GLFW_KEY_O -> Keyboard.KEY_O;
-            case GLFW.GLFW_KEY_P -> Keyboard.KEY_P;
-            case GLFW.GLFW_KEY_Q -> Keyboard.KEY_Q;
-            case GLFW.GLFW_KEY_R -> Keyboard.KEY_R;
-            case GLFW.GLFW_KEY_S -> Keyboard.KEY_S;
-            case GLFW.GLFW_KEY_T -> Keyboard.KEY_T;
-            case GLFW.GLFW_KEY_U -> Keyboard.KEY_U;
-            case GLFW.GLFW_KEY_V -> Keyboard.KEY_V;
-            case GLFW.GLFW_KEY_W -> Keyboard.KEY_W;
-            case GLFW.GLFW_KEY_X -> Keyboard.KEY_X;
-            case GLFW.GLFW_KEY_Y -> Keyboard.KEY_Y;
-            case GLFW.GLFW_KEY_Z -> Keyboard.KEY_Z;
-            case GLFW.GLFW_KEY_UP -> Keyboard.KEY_UP;
-            case GLFW.GLFW_KEY_DOWN -> Keyboard.KEY_DOWN;
-            case GLFW.GLFW_KEY_LEFT -> Keyboard.KEY_LEFT;
-            case GLFW.GLFW_KEY_RIGHT -> Keyboard.KEY_RIGHT;
-            case GLFW.GLFW_KEY_INSERT -> Keyboard.KEY_INSERT;
-            case GLFW.GLFW_KEY_DELETE -> Keyboard.KEY_DELETE;
-            case GLFW.GLFW_KEY_HOME -> Keyboard.KEY_HOME;
-            case GLFW.GLFW_KEY_END -> Keyboard.KEY_END;
-            case GLFW.GLFW_KEY_PAGE_UP -> Keyboard.KEY_PRIOR;
-            case GLFW.GLFW_KEY_PAGE_DOWN -> Keyboard.KEY_NEXT;
-            case GLFW.GLFW_KEY_F1 -> Keyboard.KEY_F1;
-            case GLFW.GLFW_KEY_F2 -> Keyboard.KEY_F2;
-            case GLFW.GLFW_KEY_F3 -> Keyboard.KEY_F3;
-            case GLFW.GLFW_KEY_F4 -> Keyboard.KEY_F4;
-            case GLFW.GLFW_KEY_F5 -> Keyboard.KEY_F5;
-            case GLFW.GLFW_KEY_F6 -> Keyboard.KEY_F6;
-            case GLFW.GLFW_KEY_F7 -> Keyboard.KEY_F7;
-            case GLFW.GLFW_KEY_F8 -> Keyboard.KEY_F8;
-            case GLFW.GLFW_KEY_F9 -> Keyboard.KEY_F9;
-            case GLFW.GLFW_KEY_F10 -> Keyboard.KEY_F10;
-            case GLFW.GLFW_KEY_F11 -> Keyboard.KEY_F11;
-            case GLFW.GLFW_KEY_F12 -> Keyboard.KEY_F12;
-            case GLFW.GLFW_KEY_F13 -> Keyboard.KEY_F13;
-            case GLFW.GLFW_KEY_F14 -> Keyboard.KEY_F14;
-            case GLFW.GLFW_KEY_F15 -> Keyboard.KEY_F15;
-            case GLFW.GLFW_KEY_F16 -> Keyboard.KEY_F16;
-            case GLFW.GLFW_KEY_F17 -> Keyboard.KEY_F17;
-            case GLFW.GLFW_KEY_F18 -> Keyboard.KEY_F18;
-            case GLFW.GLFW_KEY_F19 -> Keyboard.KEY_F19;
-            case GLFW.GLFW_KEY_KP_1 -> Keyboard.KEY_NUMPAD1;
-            case GLFW.GLFW_KEY_KP_2 -> Keyboard.KEY_NUMPAD2;
-            case GLFW.GLFW_KEY_KP_3 -> Keyboard.KEY_NUMPAD3;
-            case GLFW.GLFW_KEY_KP_4 -> Keyboard.KEY_NUMPAD4;
-            case GLFW.GLFW_KEY_KP_5 -> Keyboard.KEY_NUMPAD5;
-            case GLFW.GLFW_KEY_KP_6 -> Keyboard.KEY_NUMPAD6;
-            case GLFW.GLFW_KEY_KP_7 -> Keyboard.KEY_NUMPAD7;
-            case GLFW.GLFW_KEY_KP_8 -> Keyboard.KEY_NUMPAD8;
-            case GLFW.GLFW_KEY_KP_9 -> Keyboard.KEY_NUMPAD9;
-            case GLFW.GLFW_KEY_KP_0 -> Keyboard.KEY_NUMPAD0;
-            case GLFW.GLFW_KEY_KP_ADD -> Keyboard.KEY_ADD;
-            case GLFW.GLFW_KEY_KP_SUBTRACT -> Keyboard.KEY_SUBTRACT;
-            case GLFW.GLFW_KEY_KP_MULTIPLY -> Keyboard.KEY_MULTIPLY;
-            case GLFW.GLFW_KEY_KP_DIVIDE -> Keyboard.KEY_DIVIDE;
-            case GLFW.GLFW_KEY_KP_DECIMAL -> Keyboard.KEY_DECIMAL;
-            case GLFW.GLFW_KEY_KP_EQUAL -> Keyboard.KEY_NUMPADEQUALS;
-            case GLFW.GLFW_KEY_KP_ENTER -> Keyboard.KEY_NUMPADENTER;
-            case GLFW.GLFW_KEY_NUM_LOCK -> Keyboard.KEY_NUMLOCK;
-            case GLFW.GLFW_KEY_SEMICOLON -> Keyboard.KEY_SEMICOLON;
-            case GLFW.GLFW_KEY_BACKSLASH -> Keyboard.KEY_BACKSLASH;
-            case GLFW.GLFW_KEY_COMMA -> Keyboard.KEY_COMMA;
-            case GLFW.GLFW_KEY_PERIOD -> Keyboard.KEY_PERIOD;
-            case GLFW.GLFW_KEY_SLASH -> Keyboard.KEY_SLASH;
-            case GLFW.GLFW_KEY_GRAVE_ACCENT -> Keyboard.KEY_GRAVE;
-            case GLFW.GLFW_KEY_CAPS_LOCK -> Keyboard.KEY_CAPITAL;
-            case GLFW.GLFW_KEY_SCROLL_LOCK -> Keyboard.KEY_SCROLL;
-            case GLFW.GLFW_KEY_WORLD_1 -> Keyboard.KEY_CIRCUMFLEX; // "World" keys could be anything depending on
+        switch (glfwKeyCode) {
+            case GLFW.GLFW_KEY_UNKNOWN:
+                return Keyboard.KEY_UNLABELED; // arbitrary mapping to fix text input here
+            case GLFW.GLFW_KEY_ESCAPE:
+                return Keyboard.KEY_ESCAPE;
+            case GLFW.GLFW_KEY_BACKSPACE:
+                return Keyboard.KEY_BACK;
+            case GLFW.GLFW_KEY_TAB:
+                return Keyboard.KEY_TAB;
+            case GLFW.GLFW_KEY_ENTER:
+                return Keyboard.KEY_RETURN;
+            case GLFW.GLFW_KEY_SPACE:
+                return Keyboard.KEY_SPACE;
+            case GLFW.GLFW_KEY_LEFT_CONTROL:
+                return Keyboard.KEY_LCONTROL;
+            case GLFW.GLFW_KEY_LEFT_SHIFT:
+                return Keyboard.KEY_LSHIFT;
+            case GLFW.GLFW_KEY_LEFT_ALT:
+                return Keyboard.KEY_LMENU;
+            case GLFW.GLFW_KEY_LEFT_SUPER:
+                return Keyboard.KEY_LMETA;
+            case GLFW.GLFW_KEY_RIGHT_CONTROL:
+                return Keyboard.KEY_RCONTROL;
+            case GLFW.GLFW_KEY_RIGHT_SHIFT:
+                return Keyboard.KEY_RSHIFT;
+            case GLFW.GLFW_KEY_RIGHT_ALT:
+                return Keyboard.KEY_RMENU;
+            case GLFW.GLFW_KEY_RIGHT_SUPER:
+                return Keyboard.KEY_RMETA;
+            case GLFW.GLFW_KEY_1:
+                return Keyboard.KEY_1;
+            case GLFW.GLFW_KEY_2:
+                return Keyboard.KEY_2;
+            case GLFW.GLFW_KEY_3:
+                return Keyboard.KEY_3;
+            case GLFW.GLFW_KEY_4:
+                return Keyboard.KEY_4;
+            case GLFW.GLFW_KEY_5:
+                return Keyboard.KEY_5;
+            case GLFW.GLFW_KEY_6:
+                return Keyboard.KEY_6;
+            case GLFW.GLFW_KEY_7:
+                return Keyboard.KEY_7;
+            case GLFW.GLFW_KEY_8:
+                return Keyboard.KEY_8;
+            case GLFW.GLFW_KEY_9:
+                return Keyboard.KEY_9;
+            case GLFW.GLFW_KEY_0:
+                return Keyboard.KEY_0;
+            case GLFW.GLFW_KEY_A:
+                return Keyboard.KEY_A;
+            case GLFW.GLFW_KEY_B:
+                return Keyboard.KEY_B;
+            case GLFW.GLFW_KEY_C:
+                return Keyboard.KEY_C;
+            case GLFW.GLFW_KEY_D:
+                return Keyboard.KEY_D;
+            case GLFW.GLFW_KEY_E:
+                return Keyboard.KEY_E;
+            case GLFW.GLFW_KEY_F:
+                return Keyboard.KEY_F;
+            case GLFW.GLFW_KEY_G:
+                return Keyboard.KEY_G;
+            case GLFW.GLFW_KEY_H:
+                return Keyboard.KEY_H;
+            case GLFW.GLFW_KEY_I:
+                return Keyboard.KEY_I;
+            case GLFW.GLFW_KEY_J:
+                return Keyboard.KEY_J;
+            case GLFW.GLFW_KEY_K:
+                return Keyboard.KEY_K;
+            case GLFW.GLFW_KEY_L:
+                return Keyboard.KEY_L;
+            case GLFW.GLFW_KEY_M:
+                return Keyboard.KEY_M;
+            case GLFW.GLFW_KEY_N:
+                return Keyboard.KEY_N;
+            case GLFW.GLFW_KEY_O:
+                return Keyboard.KEY_O;
+            case GLFW.GLFW_KEY_P:
+                return Keyboard.KEY_P;
+            case GLFW.GLFW_KEY_Q:
+                return Keyboard.KEY_Q;
+            case GLFW.GLFW_KEY_R:
+                return Keyboard.KEY_R;
+            case GLFW.GLFW_KEY_S:
+                return Keyboard.KEY_S;
+            case GLFW.GLFW_KEY_T:
+                return Keyboard.KEY_T;
+            case GLFW.GLFW_KEY_U:
+                return Keyboard.KEY_U;
+            case GLFW.GLFW_KEY_V:
+                return Keyboard.KEY_V;
+            case GLFW.GLFW_KEY_W:
+                return Keyboard.KEY_W;
+            case GLFW.GLFW_KEY_X:
+                return Keyboard.KEY_X;
+            case GLFW.GLFW_KEY_Y:
+                return Keyboard.KEY_Y;
+            case GLFW.GLFW_KEY_Z:
+                return Keyboard.KEY_Z;
+            case GLFW.GLFW_KEY_UP:
+                return Keyboard.KEY_UP;
+            case GLFW.GLFW_KEY_DOWN:
+                return Keyboard.KEY_DOWN;
+            case GLFW.GLFW_KEY_LEFT:
+                return Keyboard.KEY_LEFT;
+            case GLFW.GLFW_KEY_RIGHT:
+                return Keyboard.KEY_RIGHT;
+            case GLFW.GLFW_KEY_INSERT:
+                return Keyboard.KEY_INSERT;
+            case GLFW.GLFW_KEY_DELETE:
+                return Keyboard.KEY_DELETE;
+            case GLFW.GLFW_KEY_HOME:
+                return Keyboard.KEY_HOME;
+            case GLFW.GLFW_KEY_END:
+                return Keyboard.KEY_END;
+            case GLFW.GLFW_KEY_PAGE_UP:
+                return Keyboard.KEY_PRIOR;
+            case GLFW.GLFW_KEY_PAGE_DOWN:
+                return Keyboard.KEY_NEXT;
+            case GLFW.GLFW_KEY_F1:
+                return Keyboard.KEY_F1;
+            case GLFW.GLFW_KEY_F2:
+                return Keyboard.KEY_F2;
+            case GLFW.GLFW_KEY_F3:
+                return Keyboard.KEY_F3;
+            case GLFW.GLFW_KEY_F4:
+                return Keyboard.KEY_F4;
+            case GLFW.GLFW_KEY_F5:
+                return Keyboard.KEY_F5;
+            case GLFW.GLFW_KEY_F6:
+                return Keyboard.KEY_F6;
+            case GLFW.GLFW_KEY_F7:
+                return Keyboard.KEY_F7;
+            case GLFW.GLFW_KEY_F8:
+                return Keyboard.KEY_F8;
+            case GLFW.GLFW_KEY_F9:
+                return Keyboard.KEY_F9;
+            case GLFW.GLFW_KEY_F10:
+                return Keyboard.KEY_F10;
+            case GLFW.GLFW_KEY_F11:
+                return Keyboard.KEY_F11;
+            case GLFW.GLFW_KEY_F12:
+                return Keyboard.KEY_F12;
+            case GLFW.GLFW_KEY_F13:
+                return Keyboard.KEY_F13;
+            case GLFW.GLFW_KEY_F14:
+                return Keyboard.KEY_F14;
+            case GLFW.GLFW_KEY_F15:
+                return Keyboard.KEY_F15;
+            case GLFW.GLFW_KEY_F16:
+                return Keyboard.KEY_F16;
+            case GLFW.GLFW_KEY_F17:
+                return Keyboard.KEY_F17;
+            case GLFW.GLFW_KEY_F18:
+                return Keyboard.KEY_F18;
+            case GLFW.GLFW_KEY_F19:
+                return Keyboard.KEY_F19;
+            case GLFW.GLFW_KEY_KP_1:
+                return Keyboard.KEY_NUMPAD1;
+            case GLFW.GLFW_KEY_KP_2:
+                return Keyboard.KEY_NUMPAD2;
+            case GLFW.GLFW_KEY_KP_3:
+                return Keyboard.KEY_NUMPAD3;
+            case GLFW.GLFW_KEY_KP_4:
+                return Keyboard.KEY_NUMPAD4;
+            case GLFW.GLFW_KEY_KP_5:
+                return Keyboard.KEY_NUMPAD5;
+            case GLFW.GLFW_KEY_KP_6:
+                return Keyboard.KEY_NUMPAD6;
+            case GLFW.GLFW_KEY_KP_7:
+                return Keyboard.KEY_NUMPAD7;
+            case GLFW.GLFW_KEY_KP_8:
+                return Keyboard.KEY_NUMPAD8;
+            case GLFW.GLFW_KEY_KP_9:
+                return Keyboard.KEY_NUMPAD9;
+            case GLFW.GLFW_KEY_KP_0:
+                return Keyboard.KEY_NUMPAD0;
+            case GLFW.GLFW_KEY_KP_ADD:
+                return Keyboard.KEY_ADD;
+            case GLFW.GLFW_KEY_KP_SUBTRACT:
+                return Keyboard.KEY_SUBTRACT;
+            case GLFW.GLFW_KEY_KP_MULTIPLY:
+                return Keyboard.KEY_MULTIPLY;
+            case GLFW.GLFW_KEY_KP_DIVIDE:
+                return Keyboard.KEY_DIVIDE;
+            case GLFW.GLFW_KEY_KP_DECIMAL:
+                return Keyboard.KEY_DECIMAL;
+            case GLFW.GLFW_KEY_KP_EQUAL:
+                return Keyboard.KEY_NUMPADEQUALS;
+            case GLFW.GLFW_KEY_KP_ENTER:
+                return Keyboard.KEY_NUMPADENTER;
+            case GLFW.GLFW_KEY_NUM_LOCK:
+                return Keyboard.KEY_NUMLOCK;
+            case GLFW.GLFW_KEY_SEMICOLON:
+                return Keyboard.KEY_SEMICOLON;
+            case GLFW.GLFW_KEY_BACKSLASH:
+                return Keyboard.KEY_BACKSLASH;
+            case GLFW.GLFW_KEY_COMMA:
+                return Keyboard.KEY_COMMA;
+            case GLFW.GLFW_KEY_PERIOD:
+                return Keyboard.KEY_PERIOD;
+            case GLFW.GLFW_KEY_SLASH:
+                return Keyboard.KEY_SLASH;
+            case GLFW.GLFW_KEY_GRAVE_ACCENT:
+                return Keyboard.KEY_GRAVE;
+            case GLFW.GLFW_KEY_CAPS_LOCK:
+                return Keyboard.KEY_CAPITAL;
+            case GLFW.GLFW_KEY_SCROLL_LOCK:
+                return Keyboard.KEY_SCROLL;
+            case GLFW.GLFW_KEY_WORLD_1:
+                return Keyboard.KEY_CIRCUMFLEX; // "World" keys could be anything depending on
                                                                    // keyboard layout, pick something arbitrary
-            case GLFW.GLFW_KEY_WORLD_2 -> Keyboard.KEY_YEN;
-            case GLFW.GLFW_KEY_PAUSE -> Keyboard.KEY_PAUSE;
-            case GLFW.GLFW_KEY_MINUS -> Keyboard.KEY_MINUS;
-            case GLFW.GLFW_KEY_EQUAL -> Keyboard.KEY_EQUALS;
-            case GLFW.GLFW_KEY_LEFT_BRACKET -> Keyboard.KEY_LBRACKET;
-            case GLFW.GLFW_KEY_RIGHT_BRACKET -> Keyboard.KEY_RBRACKET;
-            case GLFW.GLFW_KEY_APOSTROPHE -> Keyboard.KEY_APOSTROPHE;
+            case GLFW.GLFW_KEY_WORLD_2:
+                return Keyboard.KEY_YEN;
+            case GLFW.GLFW_KEY_PAUSE:
+                return Keyboard.KEY_PAUSE;
+            case GLFW.GLFW_KEY_MINUS:
+                return Keyboard.KEY_MINUS;
+            case GLFW.GLFW_KEY_EQUAL:
+                return Keyboard.KEY_EQUALS;
+            case GLFW.GLFW_KEY_LEFT_BRACKET:
+                return Keyboard.KEY_LBRACKET;
+            case GLFW.GLFW_KEY_RIGHT_BRACKET:
+                return Keyboard.KEY_RBRACKET;
+            case GLFW.GLFW_KEY_APOSTROPHE:
+                return Keyboard.KEY_APOSTROPHE;
             // public static final int KEY_AT = 0x91; /* (NEC PC98) */
             // public static final int KEY_COLON = 0x92; /* (NEC PC98) */
             // public static final int KEY_UNDERLINE = 0x93; /* (NEC PC98) */
@@ -148,131 +261,246 @@ public class KeyCodes {
             // public static final int KEY_POWER = 0xDE;
             // public static final int KEY_SLEEP = 0xDF;
 
-            default -> Keyboard.KEY_NONE;
-        };
+            default:
+                return Keyboard.KEY_NONE;
+        }
     }
 
     public static int lwjglToGlfw(int lwjglKeyCode) {
         if (lwjglKeyCode > GLFW.GLFW_KEY_LAST) {
             return lwjglKeyCode;
         }
-        return switch (lwjglKeyCode) {
-            case Keyboard.KEY_NONE -> 0;
-            case Keyboard.KEY_UNLABELED -> GLFW.GLFW_KEY_UNKNOWN; // arbitrary mapping to fix text input here
-            case Keyboard.KEY_ESCAPE -> GLFW.GLFW_KEY_ESCAPE;
-            case Keyboard.KEY_BACK -> GLFW.GLFW_KEY_BACKSPACE;
-            case Keyboard.KEY_TAB -> GLFW.GLFW_KEY_TAB;
-            case Keyboard.KEY_RETURN -> GLFW.GLFW_KEY_ENTER;
-            case Keyboard.KEY_SPACE -> GLFW.GLFW_KEY_SPACE;
-            case Keyboard.KEY_LCONTROL -> GLFW.GLFW_KEY_LEFT_CONTROL;
-            case Keyboard.KEY_LSHIFT -> GLFW.GLFW_KEY_LEFT_SHIFT;
-            case Keyboard.KEY_LMENU -> GLFW.GLFW_KEY_LEFT_ALT;
-            case Keyboard.KEY_LMETA -> GLFW.GLFW_KEY_LEFT_SUPER;
-            case Keyboard.KEY_RCONTROL -> GLFW.GLFW_KEY_RIGHT_CONTROL;
-            case Keyboard.KEY_RSHIFT -> GLFW.GLFW_KEY_RIGHT_SHIFT;
-            case Keyboard.KEY_RMENU -> GLFW.GLFW_KEY_RIGHT_ALT;
-            case Keyboard.KEY_RMETA -> GLFW.GLFW_KEY_RIGHT_SUPER;
-            case Keyboard.KEY_1 -> GLFW.GLFW_KEY_1;
-            case Keyboard.KEY_2 -> GLFW.GLFW_KEY_2;
-            case Keyboard.KEY_3 -> GLFW.GLFW_KEY_3;
-            case Keyboard.KEY_4 -> GLFW.GLFW_KEY_4;
-            case Keyboard.KEY_5 -> GLFW.GLFW_KEY_5;
-            case Keyboard.KEY_6 -> GLFW.GLFW_KEY_6;
-            case Keyboard.KEY_7 -> GLFW.GLFW_KEY_7;
-            case Keyboard.KEY_8 -> GLFW.GLFW_KEY_8;
-            case Keyboard.KEY_9 -> GLFW.GLFW_KEY_9;
-            case Keyboard.KEY_0 -> GLFW.GLFW_KEY_0;
-            case Keyboard.KEY_A -> GLFW.GLFW_KEY_A;
-            case Keyboard.KEY_B -> GLFW.GLFW_KEY_B;
-            case Keyboard.KEY_C -> GLFW.GLFW_KEY_C;
-            case Keyboard.KEY_D -> GLFW.GLFW_KEY_D;
-            case Keyboard.KEY_E -> GLFW.GLFW_KEY_E;
-            case Keyboard.KEY_F -> GLFW.GLFW_KEY_F;
-            case Keyboard.KEY_G -> GLFW.GLFW_KEY_G;
-            case Keyboard.KEY_H -> GLFW.GLFW_KEY_H;
-            case Keyboard.KEY_I -> GLFW.GLFW_KEY_I;
-            case Keyboard.KEY_J -> GLFW.GLFW_KEY_J;
-            case Keyboard.KEY_K -> GLFW.GLFW_KEY_K;
-            case Keyboard.KEY_L -> GLFW.GLFW_KEY_L;
-            case Keyboard.KEY_M -> GLFW.GLFW_KEY_M;
-            case Keyboard.KEY_N -> GLFW.GLFW_KEY_N;
-            case Keyboard.KEY_O -> GLFW.GLFW_KEY_O;
-            case Keyboard.KEY_P -> GLFW.GLFW_KEY_P;
-            case Keyboard.KEY_Q -> GLFW.GLFW_KEY_Q;
-            case Keyboard.KEY_R -> GLFW.GLFW_KEY_R;
-            case Keyboard.KEY_S -> GLFW.GLFW_KEY_S;
-            case Keyboard.KEY_T -> GLFW.GLFW_KEY_T;
-            case Keyboard.KEY_U -> GLFW.GLFW_KEY_U;
-            case Keyboard.KEY_V -> GLFW.GLFW_KEY_V;
-            case Keyboard.KEY_W -> GLFW.GLFW_KEY_W;
-            case Keyboard.KEY_X -> GLFW.GLFW_KEY_X;
-            case Keyboard.KEY_Y -> GLFW.GLFW_KEY_Y;
-            case Keyboard.KEY_Z -> GLFW.GLFW_KEY_Z;
-            case Keyboard.KEY_UP -> GLFW.GLFW_KEY_UP;
-            case Keyboard.KEY_DOWN -> GLFW.GLFW_KEY_DOWN;
-            case Keyboard.KEY_LEFT -> GLFW.GLFW_KEY_LEFT;
-            case Keyboard.KEY_RIGHT -> GLFW.GLFW_KEY_RIGHT;
-            case Keyboard.KEY_INSERT -> GLFW.GLFW_KEY_INSERT;
-            case Keyboard.KEY_DELETE -> GLFW.GLFW_KEY_DELETE;
-            case Keyboard.KEY_HOME -> GLFW.GLFW_KEY_HOME;
-            case Keyboard.KEY_END -> GLFW.GLFW_KEY_END;
-            case Keyboard.KEY_PRIOR -> GLFW.GLFW_KEY_PAGE_UP;
-            case Keyboard.KEY_NEXT -> GLFW.GLFW_KEY_PAGE_DOWN;
-            case Keyboard.KEY_F1 -> GLFW.GLFW_KEY_F1;
-            case Keyboard.KEY_F2 -> GLFW.GLFW_KEY_F2;
-            case Keyboard.KEY_F3 -> GLFW.GLFW_KEY_F3;
-            case Keyboard.KEY_F4 -> GLFW.GLFW_KEY_F4;
-            case Keyboard.KEY_F5 -> GLFW.GLFW_KEY_F5;
-            case Keyboard.KEY_F6 -> GLFW.GLFW_KEY_F6;
-            case Keyboard.KEY_F7 -> GLFW.GLFW_KEY_F7;
-            case Keyboard.KEY_F8 -> GLFW.GLFW_KEY_F8;
-            case Keyboard.KEY_F9 -> GLFW.GLFW_KEY_F9;
-            case Keyboard.KEY_F10 -> GLFW.GLFW_KEY_F10;
-            case Keyboard.KEY_F11 -> GLFW.GLFW_KEY_F11;
-            case Keyboard.KEY_F12 -> GLFW.GLFW_KEY_F12;
-            case Keyboard.KEY_F13 -> GLFW.GLFW_KEY_F13;
-            case Keyboard.KEY_F14 -> GLFW.GLFW_KEY_F14;
-            case Keyboard.KEY_F15 -> GLFW.GLFW_KEY_F15;
-            case Keyboard.KEY_F16 -> GLFW.GLFW_KEY_F16;
-            case Keyboard.KEY_F17 -> GLFW.GLFW_KEY_F17;
-            case Keyboard.KEY_F18 -> GLFW.GLFW_KEY_F18;
-            case Keyboard.KEY_F19 -> GLFW.GLFW_KEY_F19;
-            case Keyboard.KEY_NUMPAD1 -> GLFW.GLFW_KEY_KP_1;
-            case Keyboard.KEY_NUMPAD2 -> GLFW.GLFW_KEY_KP_2;
-            case Keyboard.KEY_NUMPAD3 -> GLFW.GLFW_KEY_KP_3;
-            case Keyboard.KEY_NUMPAD4 -> GLFW.GLFW_KEY_KP_4;
-            case Keyboard.KEY_NUMPAD5 -> GLFW.GLFW_KEY_KP_5;
-            case Keyboard.KEY_NUMPAD6 -> GLFW.GLFW_KEY_KP_6;
-            case Keyboard.KEY_NUMPAD7 -> GLFW.GLFW_KEY_KP_7;
-            case Keyboard.KEY_NUMPAD8 -> GLFW.GLFW_KEY_KP_8;
-            case Keyboard.KEY_NUMPAD9 -> GLFW.GLFW_KEY_KP_9;
-            case Keyboard.KEY_NUMPAD0 -> GLFW.GLFW_KEY_KP_0;
-            case Keyboard.KEY_ADD -> GLFW.GLFW_KEY_KP_ADD;
-            case Keyboard.KEY_SUBTRACT -> GLFW.GLFW_KEY_KP_SUBTRACT;
-            case Keyboard.KEY_MULTIPLY -> GLFW.GLFW_KEY_KP_MULTIPLY;
-            case Keyboard.KEY_DIVIDE -> GLFW.GLFW_KEY_KP_DIVIDE;
-            case Keyboard.KEY_DECIMAL -> GLFW.GLFW_KEY_KP_DECIMAL;
-            case Keyboard.KEY_NUMPADEQUALS -> GLFW.GLFW_KEY_KP_EQUAL;
-            case Keyboard.KEY_NUMPADENTER -> GLFW.GLFW_KEY_KP_ENTER;
-            case Keyboard.KEY_NUMLOCK -> GLFW.GLFW_KEY_NUM_LOCK;
-            case Keyboard.KEY_SEMICOLON -> GLFW.GLFW_KEY_SEMICOLON;
-            case Keyboard.KEY_BACKSLASH -> GLFW.GLFW_KEY_BACKSLASH;
-            case Keyboard.KEY_COMMA -> GLFW.GLFW_KEY_COMMA;
-            case Keyboard.KEY_PERIOD -> GLFW.GLFW_KEY_PERIOD;
-            case Keyboard.KEY_SLASH -> GLFW.GLFW_KEY_SLASH;
-            case Keyboard.KEY_GRAVE -> GLFW.GLFW_KEY_GRAVE_ACCENT;
-            case Keyboard.KEY_CAPITAL -> GLFW.GLFW_KEY_CAPS_LOCK;
-            case Keyboard.KEY_SCROLL -> GLFW.GLFW_KEY_SCROLL_LOCK;
-            case Keyboard.KEY_PAUSE -> GLFW.GLFW_KEY_PAUSE;
-            case Keyboard.KEY_CIRCUMFLEX -> GLFW.GLFW_KEY_WORLD_1; // "World" keys could be anything depending on
+        switch (lwjglKeyCode) {
+            case Keyboard.KEY_NONE:
+                return 0;
+            case Keyboard.KEY_UNLABELED:
+                return GLFW.GLFW_KEY_UNKNOWN; // arbitrary mapping to fix text input here
+            case Keyboard.KEY_ESCAPE:
+                return GLFW.GLFW_KEY_ESCAPE;
+            case Keyboard.KEY_BACK:
+                return GLFW.GLFW_KEY_BACKSPACE;
+            case Keyboard.KEY_TAB:
+                return GLFW.GLFW_KEY_TAB;
+            case Keyboard.KEY_RETURN:
+                return GLFW.GLFW_KEY_ENTER;
+            case Keyboard.KEY_SPACE:
+                return GLFW.GLFW_KEY_SPACE;
+            case Keyboard.KEY_LCONTROL:
+                return GLFW.GLFW_KEY_LEFT_CONTROL;
+            case Keyboard.KEY_LSHIFT:
+                return GLFW.GLFW_KEY_LEFT_SHIFT;
+            case Keyboard.KEY_LMENU:
+                return GLFW.GLFW_KEY_LEFT_ALT;
+            case Keyboard.KEY_LMETA:
+                return GLFW.GLFW_KEY_LEFT_SUPER;
+            case Keyboard.KEY_RCONTROL:
+                return GLFW.GLFW_KEY_RIGHT_CONTROL;
+            case Keyboard.KEY_RSHIFT:
+                return GLFW.GLFW_KEY_RIGHT_SHIFT;
+            case Keyboard.KEY_RMENU:
+                return GLFW.GLFW_KEY_RIGHT_ALT;
+            case Keyboard.KEY_RMETA:
+                return GLFW.GLFW_KEY_RIGHT_SUPER;
+            case Keyboard.KEY_1:
+                return GLFW.GLFW_KEY_1;
+            case Keyboard.KEY_2:
+                return GLFW.GLFW_KEY_2;
+            case Keyboard.KEY_3:
+                return GLFW.GLFW_KEY_3;
+            case Keyboard.KEY_4:
+                return GLFW.GLFW_KEY_4;
+            case Keyboard.KEY_5:
+                return GLFW.GLFW_KEY_5;
+            case Keyboard.KEY_6:
+                return GLFW.GLFW_KEY_6;
+            case Keyboard.KEY_7:
+                return GLFW.GLFW_KEY_7;
+            case Keyboard.KEY_8:
+                return GLFW.GLFW_KEY_8;
+            case Keyboard.KEY_9:
+                return GLFW.GLFW_KEY_9;
+            case Keyboard.KEY_0:
+                return GLFW.GLFW_KEY_0;
+            case Keyboard.KEY_A:
+                return GLFW.GLFW_KEY_A;
+            case Keyboard.KEY_B:
+                return GLFW.GLFW_KEY_B;
+            case Keyboard.KEY_C:
+                return GLFW.GLFW_KEY_C;
+            case Keyboard.KEY_D:
+                return GLFW.GLFW_KEY_D;
+            case Keyboard.KEY_E:
+                return GLFW.GLFW_KEY_E;
+            case Keyboard.KEY_F:
+                return GLFW.GLFW_KEY_F;
+            case Keyboard.KEY_G:
+                return GLFW.GLFW_KEY_G;
+            case Keyboard.KEY_H:
+                return GLFW.GLFW_KEY_H;
+            case Keyboard.KEY_I:
+                return GLFW.GLFW_KEY_I;
+            case Keyboard.KEY_J:
+                return GLFW.GLFW_KEY_J;
+            case Keyboard.KEY_K:
+                return GLFW.GLFW_KEY_K;
+            case Keyboard.KEY_L:
+                return GLFW.GLFW_KEY_L;
+            case Keyboard.KEY_M:
+                return GLFW.GLFW_KEY_M;
+            case Keyboard.KEY_N:
+                return GLFW.GLFW_KEY_N;
+            case Keyboard.KEY_O:
+                return GLFW.GLFW_KEY_O;
+            case Keyboard.KEY_P:
+                return GLFW.GLFW_KEY_P;
+            case Keyboard.KEY_Q:
+                return GLFW.GLFW_KEY_Q;
+            case Keyboard.KEY_R:
+                return GLFW.GLFW_KEY_R;
+            case Keyboard.KEY_S:
+                return GLFW.GLFW_KEY_S;
+            case Keyboard.KEY_T:
+                return GLFW.GLFW_KEY_T;
+            case Keyboard.KEY_U:
+                return GLFW.GLFW_KEY_U;
+            case Keyboard.KEY_V:
+                return GLFW.GLFW_KEY_V;
+            case Keyboard.KEY_W:
+                return GLFW.GLFW_KEY_W;
+            case Keyboard.KEY_X:
+                return GLFW.GLFW_KEY_X;
+            case Keyboard.KEY_Y:
+                return GLFW.GLFW_KEY_Y;
+            case Keyboard.KEY_Z:
+                return GLFW.GLFW_KEY_Z;
+            case Keyboard.KEY_UP:
+                return GLFW.GLFW_KEY_UP;
+            case Keyboard.KEY_DOWN:
+                return GLFW.GLFW_KEY_DOWN;
+            case Keyboard.KEY_LEFT:
+                return GLFW.GLFW_KEY_LEFT;
+            case Keyboard.KEY_RIGHT:
+                return GLFW.GLFW_KEY_RIGHT;
+            case Keyboard.KEY_INSERT:
+                return GLFW.GLFW_KEY_INSERT;
+            case Keyboard.KEY_DELETE:
+                return GLFW.GLFW_KEY_DELETE;
+            case Keyboard.KEY_HOME:
+                return GLFW.GLFW_KEY_HOME;
+            case Keyboard.KEY_END:
+                return GLFW.GLFW_KEY_END;
+            case Keyboard.KEY_PRIOR:
+                return GLFW.GLFW_KEY_PAGE_UP;
+            case Keyboard.KEY_NEXT:
+                return GLFW.GLFW_KEY_PAGE_DOWN;
+            case Keyboard.KEY_F1:
+                return GLFW.GLFW_KEY_F1;
+            case Keyboard.KEY_F2:
+                return GLFW.GLFW_KEY_F2;
+            case Keyboard.KEY_F3:
+                return GLFW.GLFW_KEY_F3;
+            case Keyboard.KEY_F4:
+                return GLFW.GLFW_KEY_F4;
+            case Keyboard.KEY_F5:
+                return GLFW.GLFW_KEY_F5;
+            case Keyboard.KEY_F6:
+                return GLFW.GLFW_KEY_F6;
+            case Keyboard.KEY_F7:
+                return GLFW.GLFW_KEY_F7;
+            case Keyboard.KEY_F8:
+                return GLFW.GLFW_KEY_F8;
+            case Keyboard.KEY_F9:
+                return GLFW.GLFW_KEY_F9;
+            case Keyboard.KEY_F10:
+                return GLFW.GLFW_KEY_F10;
+            case Keyboard.KEY_F11:
+                return GLFW.GLFW_KEY_F11;
+            case Keyboard.KEY_F12:
+                return GLFW.GLFW_KEY_F12;
+            case Keyboard.KEY_F13:
+                return GLFW.GLFW_KEY_F13;
+            case Keyboard.KEY_F14:
+                return GLFW.GLFW_KEY_F14;
+            case Keyboard.KEY_F15:
+                return GLFW.GLFW_KEY_F15;
+            case Keyboard.KEY_F16:
+                return GLFW.GLFW_KEY_F16;
+            case Keyboard.KEY_F17:
+                return GLFW.GLFW_KEY_F17;
+            case Keyboard.KEY_F18:
+                return GLFW.GLFW_KEY_F18;
+            case Keyboard.KEY_F19:
+                return GLFW.GLFW_KEY_F19;
+            case Keyboard.KEY_NUMPAD1:
+                return GLFW.GLFW_KEY_KP_1;
+            case Keyboard.KEY_NUMPAD2:
+                return GLFW.GLFW_KEY_KP_2;
+            case Keyboard.KEY_NUMPAD3:
+                return GLFW.GLFW_KEY_KP_3;
+            case Keyboard.KEY_NUMPAD4:
+                return GLFW.GLFW_KEY_KP_4;
+            case Keyboard.KEY_NUMPAD5:
+                return GLFW.GLFW_KEY_KP_5;
+            case Keyboard.KEY_NUMPAD6:
+                return GLFW.GLFW_KEY_KP_6;
+            case Keyboard.KEY_NUMPAD7:
+                return GLFW.GLFW_KEY_KP_7;
+            case Keyboard.KEY_NUMPAD8:
+                return GLFW.GLFW_KEY_KP_8;
+            case Keyboard.KEY_NUMPAD9:
+                return GLFW.GLFW_KEY_KP_9;
+            case Keyboard.KEY_NUMPAD0:
+                return GLFW.GLFW_KEY_KP_0;
+            case Keyboard.KEY_ADD:
+                return GLFW.GLFW_KEY_KP_ADD;
+            case Keyboard.KEY_SUBTRACT:
+                return GLFW.GLFW_KEY_KP_SUBTRACT;
+            case Keyboard.KEY_MULTIPLY:
+                return GLFW.GLFW_KEY_KP_MULTIPLY;
+            case Keyboard.KEY_DIVIDE:
+                return GLFW.GLFW_KEY_KP_DIVIDE;
+            case Keyboard.KEY_DECIMAL:
+                return GLFW.GLFW_KEY_KP_DECIMAL;
+            case Keyboard.KEY_NUMPADEQUALS:
+                return GLFW.GLFW_KEY_KP_EQUAL;
+            case Keyboard.KEY_NUMPADENTER:
+                return GLFW.GLFW_KEY_KP_ENTER;
+            case Keyboard.KEY_NUMLOCK:
+                return GLFW.GLFW_KEY_NUM_LOCK;
+            case Keyboard.KEY_SEMICOLON:
+                return GLFW.GLFW_KEY_SEMICOLON;
+            case Keyboard.KEY_BACKSLASH:
+                return GLFW.GLFW_KEY_BACKSLASH;
+            case Keyboard.KEY_COMMA:
+                return GLFW.GLFW_KEY_COMMA;
+            case Keyboard.KEY_PERIOD:
+                return GLFW.GLFW_KEY_PERIOD;
+            case Keyboard.KEY_SLASH:
+                return GLFW.GLFW_KEY_SLASH;
+            case Keyboard.KEY_GRAVE:
+                return GLFW.GLFW_KEY_GRAVE_ACCENT;
+            case Keyboard.KEY_CAPITAL:
+                return GLFW.GLFW_KEY_CAPS_LOCK;
+            case Keyboard.KEY_SCROLL:
+                return GLFW.GLFW_KEY_SCROLL_LOCK;
+            case Keyboard.KEY_PAUSE:
+                return GLFW.GLFW_KEY_PAUSE;
+            case Keyboard.KEY_CIRCUMFLEX:
+                return GLFW.GLFW_KEY_WORLD_1; // "World" keys could be anything depending on
                                                                    // keyboard layout, pick something arbitrary
-            case Keyboard.KEY_YEN -> GLFW.GLFW_KEY_WORLD_2;
+            case Keyboard.KEY_YEN:
+                return GLFW.GLFW_KEY_WORLD_2;
 
-            case Keyboard.KEY_MINUS -> GLFW.GLFW_KEY_MINUS;
-            case Keyboard.KEY_EQUALS -> GLFW.GLFW_KEY_EQUAL;
-            case Keyboard.KEY_LBRACKET -> GLFW.GLFW_KEY_LEFT_BRACKET;
-            case Keyboard.KEY_RBRACKET -> GLFW.GLFW_KEY_RIGHT_BRACKET;
-            case Keyboard.KEY_APOSTROPHE -> GLFW.GLFW_KEY_APOSTROPHE;
+            case Keyboard.KEY_MINUS:
+                return GLFW.GLFW_KEY_MINUS;
+            case Keyboard.KEY_EQUALS:
+                return GLFW.GLFW_KEY_EQUAL;
+            case Keyboard.KEY_LBRACKET:
+                return GLFW.GLFW_KEY_LEFT_BRACKET;
+            case Keyboard.KEY_RBRACKET:
+                return GLFW.GLFW_KEY_RIGHT_BRACKET;
+            case Keyboard.KEY_APOSTROPHE:
+                return GLFW.GLFW_KEY_APOSTROPHE;
             // public static final int KEY_AT = 0x91; /* (NEC PC98) */
             // public static final int KEY_COLON = 0x92; /* (NEC PC98) */
             // public static final int KEY_UNDERLINE = 0x93; /* (NEC PC98) */
@@ -298,237 +526,458 @@ public class KeyCodes {
             // public static final int KEY_POWER = 0xDE;
             // public static final int KEY_SLEEP = 0xDF;
 
-            default -> GLFW.GLFW_KEY_UNKNOWN;
-        };
+            default:
+                return GLFW.GLFW_KEY_UNKNOWN;
+        }
     }
 
     public static int awtToLwjgl(int awtCode) {
-        return switch (awtCode) {
-            case KeyEvent.VK_ESCAPE -> Keyboard.KEY_ESCAPE;
-            case KeyEvent.VK_1 -> Keyboard.KEY_1;
-            case KeyEvent.VK_2 -> Keyboard.KEY_2;
-            case KeyEvent.VK_3 -> Keyboard.KEY_3;
-            case KeyEvent.VK_4 -> Keyboard.KEY_4;
-            case KeyEvent.VK_5 -> Keyboard.KEY_5;
-            case KeyEvent.VK_6 -> Keyboard.KEY_6;
-            case KeyEvent.VK_7 -> Keyboard.KEY_7;
-            case KeyEvent.VK_8 -> Keyboard.KEY_8;
-            case KeyEvent.VK_9 -> Keyboard.KEY_9;
-            case KeyEvent.VK_0 -> Keyboard.KEY_0;
-            case KeyEvent.VK_MINUS -> Keyboard.KEY_MINUS;
-            case KeyEvent.VK_EQUALS -> Keyboard.KEY_EQUALS;
-            case KeyEvent.VK_BACK_SPACE -> Keyboard.KEY_BACK;
-            case KeyEvent.VK_TAB -> Keyboard.KEY_TAB;
-            case KeyEvent.VK_Q -> Keyboard.KEY_Q;
-            case KeyEvent.VK_W -> Keyboard.KEY_W;
-            case KeyEvent.VK_E -> Keyboard.KEY_E;
-            case KeyEvent.VK_R -> Keyboard.KEY_R;
-            case KeyEvent.VK_T -> Keyboard.KEY_T;
-            case KeyEvent.VK_Y -> Keyboard.KEY_Y;
-            case KeyEvent.VK_U -> Keyboard.KEY_U;
-            case KeyEvent.VK_I -> Keyboard.KEY_I;
-            case KeyEvent.VK_O -> Keyboard.KEY_O;
-            case KeyEvent.VK_P -> Keyboard.KEY_P;
-            case KeyEvent.VK_OPEN_BRACKET -> Keyboard.KEY_LBRACKET;
-            case KeyEvent.VK_CLOSE_BRACKET -> Keyboard.KEY_RBRACKET;
-            case KeyEvent.VK_ENTER -> Keyboard.KEY_RETURN;
-            case KeyEvent.VK_CONTROL -> Keyboard.KEY_LCONTROL;
-            case KeyEvent.VK_A -> Keyboard.KEY_A;
-            case KeyEvent.VK_S -> Keyboard.KEY_S;
-            case KeyEvent.VK_D -> Keyboard.KEY_D;
-            case KeyEvent.VK_F -> Keyboard.KEY_F;
-            case KeyEvent.VK_G -> Keyboard.KEY_G;
-            case KeyEvent.VK_H -> Keyboard.KEY_H;
-            case KeyEvent.VK_J -> Keyboard.KEY_J;
-            case KeyEvent.VK_K -> Keyboard.KEY_K;
-            case KeyEvent.VK_L -> Keyboard.KEY_L;
-            case KeyEvent.VK_SEMICOLON -> Keyboard.KEY_SEMICOLON;
-            case KeyEvent.VK_QUOTE -> Keyboard.KEY_APOSTROPHE;
-            case KeyEvent.VK_DEAD_GRAVE -> Keyboard.KEY_GRAVE;
-            case KeyEvent.VK_SHIFT -> Keyboard.KEY_LSHIFT;
-            case KeyEvent.VK_BACK_SLASH -> Keyboard.KEY_BACKSLASH;
-            case KeyEvent.VK_Z -> Keyboard.KEY_Z;
-            case KeyEvent.VK_X -> Keyboard.KEY_X;
-            case KeyEvent.VK_C -> Keyboard.KEY_C;
-            case KeyEvent.VK_V -> Keyboard.KEY_V;
-            case KeyEvent.VK_B -> Keyboard.KEY_B;
-            case KeyEvent.VK_N -> Keyboard.KEY_N;
-            case KeyEvent.VK_M -> Keyboard.KEY_M;
-            case KeyEvent.VK_COMMA -> Keyboard.KEY_COMMA;
-            case KeyEvent.VK_PERIOD -> Keyboard.KEY_PERIOD;
-            case KeyEvent.VK_SLASH -> Keyboard.KEY_SLASH;
-            case KeyEvent.VK_MULTIPLY -> Keyboard.KEY_MULTIPLY;
-            case KeyEvent.VK_ALT -> Keyboard.KEY_LMENU;
-            case KeyEvent.VK_SPACE -> Keyboard.KEY_SPACE;
-            case KeyEvent.VK_CAPS_LOCK -> Keyboard.KEY_CAPITAL;
-            case KeyEvent.VK_F1 -> Keyboard.KEY_F1;
-            case KeyEvent.VK_F2 -> Keyboard.KEY_F2;
-            case KeyEvent.VK_F3 -> Keyboard.KEY_F3;
-            case KeyEvent.VK_F4 -> Keyboard.KEY_F4;
-            case KeyEvent.VK_F5 -> Keyboard.KEY_F5;
-            case KeyEvent.VK_F6 -> Keyboard.KEY_F6;
-            case KeyEvent.VK_F7 -> Keyboard.KEY_F7;
-            case KeyEvent.VK_F8 -> Keyboard.KEY_F8;
-            case KeyEvent.VK_F9 -> Keyboard.KEY_F9;
-            case KeyEvent.VK_F10 -> Keyboard.KEY_F10;
-            case KeyEvent.VK_NUM_LOCK -> Keyboard.KEY_NUMLOCK;
-            case KeyEvent.VK_SCROLL_LOCK -> Keyboard.KEY_SCROLL;
-            case KeyEvent.VK_NUMPAD7 -> Keyboard.KEY_NUMPAD7;
-            case KeyEvent.VK_NUMPAD8 -> Keyboard.KEY_NUMPAD8;
-            case KeyEvent.VK_NUMPAD9 -> Keyboard.KEY_NUMPAD9;
-            case KeyEvent.VK_SUBTRACT -> Keyboard.KEY_SUBTRACT;
-            case KeyEvent.VK_NUMPAD4 -> Keyboard.KEY_NUMPAD4;
-            case KeyEvent.VK_NUMPAD5 -> Keyboard.KEY_NUMPAD5;
-            case KeyEvent.VK_NUMPAD6 -> Keyboard.KEY_NUMPAD6;
-            case KeyEvent.VK_ADD -> Keyboard.KEY_ADD;
-            case KeyEvent.VK_NUMPAD1 -> Keyboard.KEY_NUMPAD1;
-            case KeyEvent.VK_NUMPAD2 -> Keyboard.KEY_NUMPAD2;
-            case KeyEvent.VK_NUMPAD3 -> Keyboard.KEY_NUMPAD3;
-            case KeyEvent.VK_NUMPAD0 -> Keyboard.KEY_NUMPAD0;
-            case KeyEvent.VK_DECIMAL -> Keyboard.KEY_DECIMAL;
-            case KeyEvent.VK_F11 -> Keyboard.KEY_F11;
-            case KeyEvent.VK_F12 -> Keyboard.KEY_F12;
-            case KeyEvent.VK_F13 -> Keyboard.KEY_F13;
-            case KeyEvent.VK_F14 -> Keyboard.KEY_F14;
-            case KeyEvent.VK_F15 -> Keyboard.KEY_F15;
-            case KeyEvent.VK_KANA -> Keyboard.KEY_KANA;
-            case KeyEvent.VK_CONVERT -> Keyboard.KEY_CONVERT;
-            case KeyEvent.VK_NONCONVERT -> Keyboard.KEY_NOCONVERT;
-            case KeyEvent.VK_CIRCUMFLEX -> Keyboard.KEY_CIRCUMFLEX;
-            case KeyEvent.VK_AT -> Keyboard.KEY_AT;
-            case KeyEvent.VK_COLON -> Keyboard.KEY_COLON;
-            case KeyEvent.VK_UNDERSCORE -> Keyboard.KEY_UNDERLINE;
-            case KeyEvent.VK_KANJI -> Keyboard.KEY_KANJI;
-            case KeyEvent.VK_STOP -> Keyboard.KEY_STOP;
-            case KeyEvent.VK_DIVIDE -> Keyboard.KEY_DIVIDE;
-            case KeyEvent.VK_PAUSE -> Keyboard.KEY_PAUSE;
-            case KeyEvent.VK_HOME -> Keyboard.KEY_HOME;
-            case KeyEvent.VK_UP -> Keyboard.KEY_UP;
-            case KeyEvent.VK_PAGE_UP -> Keyboard.KEY_PRIOR;
-            case KeyEvent.VK_LEFT -> Keyboard.KEY_LEFT;
-            case KeyEvent.VK_RIGHT -> Keyboard.KEY_RIGHT;
-            case KeyEvent.VK_END -> Keyboard.KEY_END;
-            case KeyEvent.VK_DOWN -> Keyboard.KEY_DOWN;
-            case KeyEvent.VK_PAGE_DOWN -> Keyboard.KEY_NEXT;
-            case KeyEvent.VK_INSERT -> Keyboard.KEY_INSERT;
-            case KeyEvent.VK_DELETE -> Keyboard.KEY_DELETE;
-            case KeyEvent.VK_META -> Keyboard.KEY_LWIN;
-            default -> Keyboard.KEY_NONE;
-        };
+        switch (awtCode) {
+            case KeyEvent.VK_ESCAPE:
+                return Keyboard.KEY_ESCAPE;
+            case KeyEvent.VK_1:
+                return Keyboard.KEY_1;
+            case KeyEvent.VK_2:
+                return Keyboard.KEY_2;
+            case KeyEvent.VK_3:
+                return Keyboard.KEY_3;
+            case KeyEvent.VK_4:
+                return Keyboard.KEY_4;
+            case KeyEvent.VK_5:
+                return Keyboard.KEY_5;
+            case KeyEvent.VK_6:
+                return Keyboard.KEY_6;
+            case KeyEvent.VK_7:
+                return Keyboard.KEY_7;
+            case KeyEvent.VK_8:
+                return Keyboard.KEY_8;
+            case KeyEvent.VK_9:
+                return Keyboard.KEY_9;
+            case KeyEvent.VK_0:
+                return Keyboard.KEY_0;
+            case KeyEvent.VK_MINUS:
+                return Keyboard.KEY_MINUS;
+            case KeyEvent.VK_EQUALS:
+                return Keyboard.KEY_EQUALS;
+            case KeyEvent.VK_BACK_SPACE:
+                return Keyboard.KEY_BACK;
+            case KeyEvent.VK_TAB:
+                return Keyboard.KEY_TAB;
+            case KeyEvent.VK_Q:
+                return Keyboard.KEY_Q;
+            case KeyEvent.VK_W:
+                return Keyboard.KEY_W;
+            case KeyEvent.VK_E:
+                return Keyboard.KEY_E;
+            case KeyEvent.VK_R:
+                return Keyboard.KEY_R;
+            case KeyEvent.VK_T:
+                return Keyboard.KEY_T;
+            case KeyEvent.VK_Y:
+                return Keyboard.KEY_Y;
+            case KeyEvent.VK_U:
+                return Keyboard.KEY_U;
+            case KeyEvent.VK_I:
+                return Keyboard.KEY_I;
+            case KeyEvent.VK_O:
+                return Keyboard.KEY_O;
+            case KeyEvent.VK_P:
+                return Keyboard.KEY_P;
+            case KeyEvent.VK_OPEN_BRACKET:
+                return Keyboard.KEY_LBRACKET;
+            case KeyEvent.VK_CLOSE_BRACKET:
+                return Keyboard.KEY_RBRACKET;
+            case KeyEvent.VK_ENTER:
+                return Keyboard.KEY_RETURN;
+            case KeyEvent.VK_CONTROL:
+                return Keyboard.KEY_LCONTROL;
+            case KeyEvent.VK_A:
+                return Keyboard.KEY_A;
+            case KeyEvent.VK_S:
+                return Keyboard.KEY_S;
+            case KeyEvent.VK_D:
+                return Keyboard.KEY_D;
+            case KeyEvent.VK_F:
+                return Keyboard.KEY_F;
+            case KeyEvent.VK_G:
+                return Keyboard.KEY_G;
+            case KeyEvent.VK_H:
+                return Keyboard.KEY_H;
+            case KeyEvent.VK_J:
+                return Keyboard.KEY_J;
+            case KeyEvent.VK_K:
+                return Keyboard.KEY_K;
+            case KeyEvent.VK_L:
+                return Keyboard.KEY_L;
+            case KeyEvent.VK_SEMICOLON:
+                return Keyboard.KEY_SEMICOLON;
+            case KeyEvent.VK_QUOTE:
+                return Keyboard.KEY_APOSTROPHE;
+            case KeyEvent.VK_DEAD_GRAVE:
+                return Keyboard.KEY_GRAVE;
+            case KeyEvent.VK_SHIFT:
+                return Keyboard.KEY_LSHIFT;
+            case KeyEvent.VK_BACK_SLASH:
+                return Keyboard.KEY_BACKSLASH;
+            case KeyEvent.VK_Z:
+                return Keyboard.KEY_Z;
+            case KeyEvent.VK_X:
+                return Keyboard.KEY_X;
+            case KeyEvent.VK_C:
+                return Keyboard.KEY_C;
+            case KeyEvent.VK_V:
+                return Keyboard.KEY_V;
+            case KeyEvent.VK_B:
+                return Keyboard.KEY_B;
+            case KeyEvent.VK_N:
+                return Keyboard.KEY_N;
+            case KeyEvent.VK_M:
+                return Keyboard.KEY_M;
+            case KeyEvent.VK_COMMA:
+                return Keyboard.KEY_COMMA;
+            case KeyEvent.VK_PERIOD:
+                return Keyboard.KEY_PERIOD;
+            case KeyEvent.VK_SLASH:
+                return Keyboard.KEY_SLASH;
+            case KeyEvent.VK_MULTIPLY:
+                return Keyboard.KEY_MULTIPLY;
+            case KeyEvent.VK_ALT:
+                return Keyboard.KEY_LMENU;
+            case KeyEvent.VK_SPACE:
+                return Keyboard.KEY_SPACE;
+            case KeyEvent.VK_CAPS_LOCK:;
+                return Keyboard.KEY_CAPITAL;
+            case KeyEvent.VK_F1:
+                return Keyboard.KEY_F1;
+            case KeyEvent.VK_F2:
+                return Keyboard.KEY_F2;
+            case KeyEvent.VK_F3:
+                return Keyboard.KEY_F3;
+            case KeyEvent.VK_F4:
+                return Keyboard.KEY_F4;
+            case KeyEvent.VK_F5:
+                return Keyboard.KEY_F5;
+            case KeyEvent.VK_F6:
+                return Keyboard.KEY_F6;
+            case KeyEvent.VK_F7:
+                return Keyboard.KEY_F7;
+            case KeyEvent.VK_F8:
+                return Keyboard.KEY_F8;
+            case KeyEvent.VK_F9:
+                return Keyboard.KEY_F9;
+            case KeyEvent.VK_F10:
+                return Keyboard.KEY_F10;
+            case KeyEvent.VK_NUM_LOCK:
+                return Keyboard.KEY_NUMLOCK;
+            case KeyEvent.VK_SCROLL_LOCK:
+                return Keyboard.KEY_SCROLL;
+            case KeyEvent.VK_NUMPAD7:
+                return Keyboard.KEY_NUMPAD7;
+            case KeyEvent.VK_NUMPAD8:
+                return Keyboard.KEY_NUMPAD8;
+            case KeyEvent.VK_NUMPAD9:
+                return Keyboard.KEY_NUMPAD9;
+            case KeyEvent.VK_SUBTRACT:
+                return Keyboard.KEY_SUBTRACT;
+            case KeyEvent.VK_NUMPAD4:
+                return Keyboard.KEY_NUMPAD4;
+            case KeyEvent.VK_NUMPAD5:
+                return Keyboard.KEY_NUMPAD5;
+            case KeyEvent.VK_NUMPAD6:
+                return Keyboard.KEY_NUMPAD6;
+            case KeyEvent.VK_ADD:
+                return Keyboard.KEY_ADD;
+            case KeyEvent.VK_NUMPAD1:
+                return Keyboard.KEY_NUMPAD1;
+            case KeyEvent.VK_NUMPAD2:
+                return Keyboard.KEY_NUMPAD2;
+            case KeyEvent.VK_NUMPAD3:
+                return Keyboard.KEY_NUMPAD3;
+            case KeyEvent.VK_NUMPAD0:
+                return Keyboard.KEY_NUMPAD0;
+            case KeyEvent.VK_DECIMAL:
+                return Keyboard.KEY_DECIMAL;
+            case KeyEvent.VK_F11:
+                return Keyboard.KEY_F11;
+            case KeyEvent.VK_F12:
+                return Keyboard.KEY_F12;
+            case KeyEvent.VK_F13:
+                return Keyboard.KEY_F13;
+            case KeyEvent.VK_F14:
+                return Keyboard.KEY_F14;
+            case KeyEvent.VK_F15:
+                return Keyboard.KEY_F15;
+            case KeyEvent.VK_KANA:
+                return Keyboard.KEY_KANA;
+            case KeyEvent.VK_CONVERT:
+                return Keyboard.KEY_CONVERT;
+            case KeyEvent.VK_NONCONVERT:
+                return Keyboard.KEY_NOCONVERT;
+            case KeyEvent.VK_CIRCUMFLEX:
+                return Keyboard.KEY_CIRCUMFLEX;
+            case KeyEvent.VK_AT:
+                return Keyboard.KEY_AT;
+            case KeyEvent.VK_COLON:
+                return Keyboard.KEY_COLON;
+            case KeyEvent.VK_UNDERSCORE:
+                return Keyboard.KEY_UNDERLINE;
+            case KeyEvent.VK_KANJI:
+                return Keyboard.KEY_KANJI;
+            case KeyEvent.VK_STOP:
+                return Keyboard.KEY_STOP;
+            case KeyEvent.VK_DIVIDE:
+                return Keyboard.KEY_DIVIDE;
+            case KeyEvent.VK_PAUSE:
+                return Keyboard.KEY_PAUSE;
+            case KeyEvent.VK_HOME:
+                return Keyboard.KEY_HOME;
+            case KeyEvent.VK_UP:
+                return Keyboard.KEY_UP;
+            case KeyEvent.VK_PAGE_UP:
+                return Keyboard.KEY_PRIOR;
+            case KeyEvent.VK_LEFT:
+                return Keyboard.KEY_LEFT;
+            case KeyEvent.VK_RIGHT:
+                return Keyboard.KEY_RIGHT;
+            case KeyEvent.VK_END:
+                return Keyboard.KEY_END;
+            case KeyEvent.VK_DOWN:
+                return Keyboard.KEY_DOWN;
+            case KeyEvent.VK_PAGE_DOWN:
+                return Keyboard.KEY_NEXT;
+            case KeyEvent.VK_INSERT:
+                return Keyboard.KEY_INSERT;
+            case KeyEvent.VK_DELETE:
+                return Keyboard.KEY_DELETE;
+            case KeyEvent.VK_META:
+                return Keyboard.KEY_LWIN;
+            default:
+                return Keyboard.KEY_NONE;
+        }
     }
 
     public static int lwjglToAwt(int lwjglCode) {
-        return switch (lwjglCode) {
-            case Keyboard.KEY_ESCAPE -> KeyEvent.VK_ESCAPE;
-            case Keyboard.KEY_1 -> KeyEvent.VK_1;
-            case Keyboard.KEY_2 -> KeyEvent.VK_2;
-            case Keyboard.KEY_3 -> KeyEvent.VK_3;
-            case Keyboard.KEY_4 -> KeyEvent.VK_4;
-            case Keyboard.KEY_5 -> KeyEvent.VK_5;
-            case Keyboard.KEY_6 -> KeyEvent.VK_6;
-            case Keyboard.KEY_7 -> KeyEvent.VK_7;
-            case Keyboard.KEY_8 -> KeyEvent.VK_8;
-            case Keyboard.KEY_9 -> KeyEvent.VK_9;
-            case Keyboard.KEY_0 -> KeyEvent.VK_0;
-            case Keyboard.KEY_MINUS -> KeyEvent.VK_MINUS;
-            case Keyboard.KEY_EQUALS -> KeyEvent.VK_EQUALS;
-            case Keyboard.KEY_BACK -> KeyEvent.VK_BACK_SPACE;
-            case Keyboard.KEY_TAB -> KeyEvent.VK_TAB;
-            case Keyboard.KEY_Q -> KeyEvent.VK_Q;
-            case Keyboard.KEY_W -> KeyEvent.VK_W;
-            case Keyboard.KEY_E -> KeyEvent.VK_E;
-            case Keyboard.KEY_R -> KeyEvent.VK_R;
-            case Keyboard.KEY_T -> KeyEvent.VK_T;
-            case Keyboard.KEY_Y -> KeyEvent.VK_Y;
-            case Keyboard.KEY_U -> KeyEvent.VK_U;
-            case Keyboard.KEY_I -> KeyEvent.VK_I;
-            case Keyboard.KEY_O -> KeyEvent.VK_O;
-            case Keyboard.KEY_P -> KeyEvent.VK_P;
-            case Keyboard.KEY_LBRACKET -> KeyEvent.VK_OPEN_BRACKET;
-            case Keyboard.KEY_RBRACKET -> KeyEvent.VK_CLOSE_BRACKET;
-            case Keyboard.KEY_RETURN -> KeyEvent.VK_ENTER;
-            case Keyboard.KEY_LCONTROL -> KeyEvent.VK_CONTROL;
-            case Keyboard.KEY_A -> KeyEvent.VK_A;
-            case Keyboard.KEY_S -> KeyEvent.VK_S;
-            case Keyboard.KEY_D -> KeyEvent.VK_D;
-            case Keyboard.KEY_F -> KeyEvent.VK_F;
-            case Keyboard.KEY_G -> KeyEvent.VK_G;
-            case Keyboard.KEY_H -> KeyEvent.VK_H;
-            case Keyboard.KEY_J -> KeyEvent.VK_J;
-            case Keyboard.KEY_K -> KeyEvent.VK_K;
-            case Keyboard.KEY_L -> KeyEvent.VK_L;
-            case Keyboard.KEY_SEMICOLON -> KeyEvent.VK_SEMICOLON;
-            case Keyboard.KEY_APOSTROPHE -> KeyEvent.VK_QUOTE;
-            case Keyboard.KEY_GRAVE -> KeyEvent.VK_DEAD_GRAVE;
-            case Keyboard.KEY_LSHIFT -> KeyEvent.VK_SHIFT;
-            case Keyboard.KEY_BACKSLASH -> KeyEvent.VK_BACK_SLASH;
-            case Keyboard.KEY_Z -> KeyEvent.VK_Z;
-            case Keyboard.KEY_X -> KeyEvent.VK_X;
-            case Keyboard.KEY_C -> KeyEvent.VK_C;
-            case Keyboard.KEY_V -> KeyEvent.VK_V;
-            case Keyboard.KEY_B -> KeyEvent.VK_B;
-            case Keyboard.KEY_N -> KeyEvent.VK_N;
-            case Keyboard.KEY_M -> KeyEvent.VK_M;
-            case Keyboard.KEY_COMMA -> KeyEvent.VK_COMMA;
-            case Keyboard.KEY_PERIOD -> KeyEvent.VK_PERIOD;
-            case Keyboard.KEY_SLASH -> KeyEvent.VK_SLASH;
-            case Keyboard.KEY_MULTIPLY -> KeyEvent.VK_MULTIPLY;
-            case Keyboard.KEY_LMENU -> KeyEvent.VK_ALT;
-            case Keyboard.KEY_SPACE -> KeyEvent.VK_SPACE;
-            case Keyboard.KEY_CAPITAL -> KeyEvent.VK_CAPS_LOCK;
-            case Keyboard.KEY_F1 -> KeyEvent.VK_F1;
-            case Keyboard.KEY_F2 -> KeyEvent.VK_F2;
-            case Keyboard.KEY_F3 -> KeyEvent.VK_F3;
-            case Keyboard.KEY_F4 -> KeyEvent.VK_F4;
-            case Keyboard.KEY_F5 -> KeyEvent.VK_F5;
-            case Keyboard.KEY_F6 -> KeyEvent.VK_F6;
-            case Keyboard.KEY_F7 -> KeyEvent.VK_F7;
-            case Keyboard.KEY_F8 -> KeyEvent.VK_F8;
-            case Keyboard.KEY_F9 -> KeyEvent.VK_F9;
-            case Keyboard.KEY_F10 -> KeyEvent.VK_F10;
-            case Keyboard.KEY_NUMLOCK -> KeyEvent.VK_NUM_LOCK;
-            case Keyboard.KEY_SCROLL -> KeyEvent.VK_SCROLL_LOCK;
-            case Keyboard.KEY_NUMPAD7 -> KeyEvent.VK_NUMPAD7;
-            case Keyboard.KEY_NUMPAD8 -> KeyEvent.VK_NUMPAD8;
-            case Keyboard.KEY_NUMPAD9 -> KeyEvent.VK_NUMPAD9;
-            case Keyboard.KEY_SUBTRACT -> KeyEvent.VK_SUBTRACT;
-            case Keyboard.KEY_NUMPAD4 -> KeyEvent.VK_NUMPAD4;
-            case Keyboard.KEY_NUMPAD5 -> KeyEvent.VK_NUMPAD5;
-            case Keyboard.KEY_NUMPAD6 -> KeyEvent.VK_NUMPAD6;
-            case Keyboard.KEY_ADD -> KeyEvent.VK_ADD;
-            case Keyboard.KEY_NUMPAD1 -> KeyEvent.VK_NUMPAD1;
-            case Keyboard.KEY_NUMPAD2 -> KeyEvent.VK_NUMPAD2;
-            case Keyboard.KEY_NUMPAD3 -> KeyEvent.VK_NUMPAD3;
-            case Keyboard.KEY_NUMPAD0 -> KeyEvent.VK_NUMPAD0;
-            case Keyboard.KEY_DECIMAL -> KeyEvent.VK_DECIMAL;
-            case Keyboard.KEY_F11 -> KeyEvent.VK_F11;
-            case Keyboard.KEY_F12 -> KeyEvent.VK_F12;
-            case Keyboard.KEY_F13 -> KeyEvent.VK_F13;
-            case Keyboard.KEY_F14 -> KeyEvent.VK_F14;
-            case Keyboard.KEY_F15 -> KeyEvent.VK_F15;
-            case Keyboard.KEY_KANA -> KeyEvent.VK_KANA;
-            case Keyboard.KEY_CONVERT -> KeyEvent.VK_CONVERT;
-            case Keyboard.KEY_NOCONVERT -> KeyEvent.VK_NONCONVERT;
-            case Keyboard.KEY_CIRCUMFLEX -> KeyEvent.VK_CIRCUMFLEX;
-            case Keyboard.KEY_AT -> KeyEvent.VK_AT;
-            case Keyboard.KEY_COLON -> KeyEvent.VK_COLON;
-            case Keyboard.KEY_UNDERLINE -> KeyEvent.VK_UNDERSCORE;
-            case Keyboard.KEY_KANJI -> KeyEvent.VK_KANJI;
-            case Keyboard.KEY_STOP -> KeyEvent.VK_STOP;
-            case Keyboard.KEY_DIVIDE -> KeyEvent.VK_DIVIDE;
-            case Keyboard.KEY_PAUSE -> KeyEvent.VK_PAUSE;
-            case Keyboard.KEY_HOME -> KeyEvent.VK_HOME;
-            case Keyboard.KEY_UP -> KeyEvent.VK_UP;
-            case Keyboard.KEY_PRIOR -> KeyEvent.VK_PAGE_UP;
-            case Keyboard.KEY_LEFT -> KeyEvent.VK_LEFT;
-            case Keyboard.KEY_RIGHT -> KeyEvent.VK_RIGHT;
-            case Keyboard.KEY_END -> KeyEvent.VK_END;
-            case Keyboard.KEY_DOWN -> KeyEvent.VK_DOWN;
-            case Keyboard.KEY_NEXT -> KeyEvent.VK_PAGE_DOWN;
-            case Keyboard.KEY_INSERT -> KeyEvent.VK_INSERT;
-            case Keyboard.KEY_DELETE -> KeyEvent.VK_DELETE;
-            case Keyboard.KEY_LWIN -> KeyEvent.VK_META;
-            default -> Keyboard.KEY_NONE;
-        };
+        switch (lwjglCode) {
+            case Keyboard.KEY_ESCAPE:
+                return KeyEvent.VK_ESCAPE;
+            case Keyboard.KEY_1:
+                return KeyEvent.VK_1;
+            case Keyboard.KEY_2:
+                return KeyEvent.VK_2;
+            case Keyboard.KEY_3:
+                return KeyEvent.VK_3;
+            case Keyboard.KEY_4:
+                return KeyEvent.VK_4;
+            case Keyboard.KEY_5:
+                return KeyEvent.VK_5;
+            case Keyboard.KEY_6:
+                return KeyEvent.VK_6;
+            case Keyboard.KEY_7:
+                return KeyEvent.VK_7;
+            case Keyboard.KEY_8:
+                return KeyEvent.VK_8;
+            case Keyboard.KEY_9:
+                return KeyEvent.VK_9;
+            case Keyboard.KEY_0:
+                return KeyEvent.VK_0;
+            case Keyboard.KEY_MINUS:
+                return KeyEvent.VK_MINUS;
+            case Keyboard.KEY_EQUALS:
+                return KeyEvent.VK_EQUALS;
+            case Keyboard.KEY_BACK:
+                return KeyEvent.VK_BACK_SPACE;
+            case Keyboard.KEY_TAB:
+                return KeyEvent.VK_TAB;
+            case Keyboard.KEY_Q:
+                return KeyEvent.VK_Q;
+            case Keyboard.KEY_W:
+                return KeyEvent.VK_W;
+            case Keyboard.KEY_E:
+                return KeyEvent.VK_E;
+            case Keyboard.KEY_R:
+                return KeyEvent.VK_R;
+            case Keyboard.KEY_T:
+                return KeyEvent.VK_T;
+            case Keyboard.KEY_Y:
+                return KeyEvent.VK_Y;
+            case Keyboard.KEY_U:
+                return KeyEvent.VK_U;
+            case Keyboard.KEY_I:
+                return KeyEvent.VK_I;
+            case Keyboard.KEY_O:
+                return KeyEvent.VK_O;
+            case Keyboard.KEY_P:
+                return KeyEvent.VK_P;
+            case Keyboard.KEY_LBRACKET:
+                return KeyEvent.VK_OPEN_BRACKET;
+            case Keyboard.KEY_RBRACKET:
+                return KeyEvent.VK_CLOSE_BRACKET;
+            case Keyboard.KEY_RETURN:
+                return KeyEvent.VK_ENTER;
+            case Keyboard.KEY_LCONTROL:
+                return KeyEvent.VK_CONTROL;
+            case Keyboard.KEY_A:
+                return KeyEvent.VK_A;
+            case Keyboard.KEY_S:
+                return KeyEvent.VK_S;
+            case Keyboard.KEY_D:
+                return KeyEvent.VK_D;
+            case Keyboard.KEY_F:
+                return KeyEvent.VK_F;
+            case Keyboard.KEY_G:
+                return KeyEvent.VK_G;
+            case Keyboard.KEY_H:
+                return KeyEvent.VK_H;
+            case Keyboard.KEY_J:
+                return KeyEvent.VK_J;
+            case Keyboard.KEY_K:
+                return KeyEvent.VK_K;
+            case Keyboard.KEY_L:
+                return KeyEvent.VK_L;
+            case Keyboard.KEY_SEMICOLON:
+                return KeyEvent.VK_SEMICOLON;
+            case Keyboard.KEY_APOSTROPHE:
+                return KeyEvent.VK_QUOTE;
+            case Keyboard.KEY_GRAVE:
+                return KeyEvent.VK_DEAD_GRAVE;
+            case Keyboard.KEY_LSHIFT:
+                return KeyEvent.VK_SHIFT;
+            case Keyboard.KEY_BACKSLASH:
+                return KeyEvent.VK_BACK_SLASH;
+            case Keyboard.KEY_Z:
+                return KeyEvent.VK_Z;
+            case Keyboard.KEY_X:
+                return KeyEvent.VK_X;
+            case Keyboard.KEY_C:
+                return KeyEvent.VK_C;
+            case Keyboard.KEY_V:
+                return KeyEvent.VK_V;
+            case Keyboard.KEY_B:
+                return KeyEvent.VK_B;
+            case Keyboard.KEY_N:
+                return KeyEvent.VK_N;
+            case Keyboard.KEY_M:
+                return KeyEvent.VK_M;
+            case Keyboard.KEY_COMMA:
+                return KeyEvent.VK_COMMA;
+            case Keyboard.KEY_PERIOD:
+                return KeyEvent.VK_PERIOD;
+            case Keyboard.KEY_SLASH:
+                return KeyEvent.VK_SLASH;
+            case Keyboard.KEY_MULTIPLY:
+                return KeyEvent.VK_MULTIPLY;
+            case Keyboard.KEY_LMENU:
+                return KeyEvent.VK_ALT;
+            case Keyboard.KEY_SPACE:
+                return KeyEvent.VK_SPACE;
+            case Keyboard.KEY_CAPITAL:
+                return KeyEvent.VK_CAPS_LOCK;
+            case Keyboard.KEY_F1:
+                return KeyEvent.VK_F1;
+            case Keyboard.KEY_F2:
+                return KeyEvent.VK_F2;
+            case Keyboard.KEY_F3:
+                return KeyEvent.VK_F3;
+            case Keyboard.KEY_F4:
+                return KeyEvent.VK_F4;
+            case Keyboard.KEY_F5:
+                return KeyEvent.VK_F5;
+            case Keyboard.KEY_F6:
+                return KeyEvent.VK_F6;
+            case Keyboard.KEY_F7:
+                return KeyEvent.VK_F7;
+            case Keyboard.KEY_F8:
+                return KeyEvent.VK_F8;
+            case Keyboard.KEY_F9:
+                return KeyEvent.VK_F9;
+            case Keyboard.KEY_F10:
+                return KeyEvent.VK_F10;
+            case Keyboard.KEY_NUMLOCK:
+                return KeyEvent.VK_NUM_LOCK;
+            case Keyboard.KEY_SCROLL:
+                return KeyEvent.VK_SCROLL_LOCK;
+            case Keyboard.KEY_NUMPAD7:
+                return KeyEvent.VK_NUMPAD7;
+            case Keyboard.KEY_NUMPAD8:
+                return KeyEvent.VK_NUMPAD8;
+            case Keyboard.KEY_NUMPAD9:
+                return KeyEvent.VK_NUMPAD9;
+            case Keyboard.KEY_SUBTRACT:
+                return KeyEvent.VK_SUBTRACT;
+            case Keyboard.KEY_NUMPAD4:
+                return KeyEvent.VK_NUMPAD4;
+            case Keyboard.KEY_NUMPAD5:
+                return KeyEvent.VK_NUMPAD5;
+            case Keyboard.KEY_NUMPAD6:
+                return KeyEvent.VK_NUMPAD6;
+            case Keyboard.KEY_ADD:
+                return KeyEvent.VK_ADD;
+            case Keyboard.KEY_NUMPAD1:
+                return KeyEvent.VK_NUMPAD1;
+            case Keyboard.KEY_NUMPAD2:
+                return KeyEvent.VK_NUMPAD2;
+            case Keyboard.KEY_NUMPAD3:
+                return KeyEvent.VK_NUMPAD3;
+            case Keyboard.KEY_NUMPAD0:
+                return KeyEvent.VK_NUMPAD0;
+            case Keyboard.KEY_DECIMAL:
+                return KeyEvent.VK_DECIMAL;
+            case Keyboard.KEY_F11:
+                return KeyEvent.VK_F11;
+            case Keyboard.KEY_F12:
+                return KeyEvent.VK_F12;
+            case Keyboard.KEY_F13:
+                return KeyEvent.VK_F13;
+            case Keyboard.KEY_F14:
+                return KeyEvent.VK_F14;
+            case Keyboard.KEY_F15:
+                return KeyEvent.VK_F15;
+            case Keyboard.KEY_KANA:
+                return KeyEvent.VK_KANA;
+            case Keyboard.KEY_CONVERT:
+                return KeyEvent.VK_CONVERT;
+            case Keyboard.KEY_NOCONVERT:
+                return KeyEvent.VK_NONCONVERT;
+            case Keyboard.KEY_CIRCUMFLEX:
+                return KeyEvent.VK_CIRCUMFLEX;
+            case Keyboard.KEY_AT:
+                return KeyEvent.VK_AT;
+            case Keyboard.KEY_COLON:
+                return KeyEvent.VK_COLON;
+            case Keyboard.KEY_UNDERLINE:
+                return KeyEvent.VK_UNDERSCORE;
+            case Keyboard.KEY_KANJI:
+                return KeyEvent.VK_KANJI;
+            case Keyboard.KEY_STOP:
+                return KeyEvent.VK_STOP;
+            case Keyboard.KEY_DIVIDE:
+                return KeyEvent.VK_DIVIDE;
+            case Keyboard.KEY_PAUSE:
+                return KeyEvent.VK_PAUSE;
+            case Keyboard.KEY_HOME:
+                return KeyEvent.VK_HOME;
+            case Keyboard.KEY_UP:
+                return KeyEvent.VK_UP;
+            case Keyboard.KEY_PRIOR:
+                return KeyEvent.VK_PAGE_UP;
+            case Keyboard.KEY_LEFT:
+                return KeyEvent.VK_LEFT;
+            case Keyboard.KEY_RIGHT:
+                return KeyEvent.VK_RIGHT;
+            case Keyboard.KEY_END:
+                return KeyEvent.VK_END;
+            case Keyboard.KEY_DOWN:
+                return KeyEvent.VK_DOWN;
+            case Keyboard.KEY_NEXT:
+                return KeyEvent.VK_PAGE_DOWN;
+            case Keyboard.KEY_INSERT:
+                return KeyEvent.VK_INSERT;
+            case Keyboard.KEY_DELETE:
+                return KeyEvent.VK_DELETE;
+            case Keyboard.KEY_LWIN:
+                return KeyEvent.VK_META;
+            default:
+                return Keyboard.KEY_NONE;
+        }
     }
 }

--- a/src/main/java/org/lwjglx/input/Keyboard.java
+++ b/src/main/java/org/lwjglx/input/Keyboard.java
@@ -245,11 +245,20 @@ public class Keyboard {
     }
 
     public static void addGlfwKeyEvent(long window, int key, int scancode, int action, int mods, char c) {
-        final KeyState state = switch (action) {
-            case GLFW.GLFW_PRESS -> KeyState.PRESS;
-            case GLFW.GLFW_RELEASE -> KeyState.RELEASE;
-            case GLFW.GLFW_REPEAT -> KeyState.REPEAT;
-            default -> KeyState.RELEASE;
+        KeyState state = null;
+        switch (action) {
+            case GLFW.GLFW_PRESS:
+                state = KeyState.PRESS;
+                break;
+            case GLFW.GLFW_RELEASE:
+                state = KeyState.RELEASE;
+                break;
+            case GLFW.GLFW_REPEAT:
+                state = KeyState.REPEAT;
+                break;
+            default:
+                state = KeyState.RELEASE;
+                break;
         };
         addRawKeyEvent(new KeyEvent(KeyCodes.glfwToLwjgl(key), c, state, Sys.getNanoTime()));
     }

--- a/src/main/java/org/lwjglx/openal/EFXUtil.java
+++ b/src/main/java/org/lwjglx/openal/EFXUtil.java
@@ -129,10 +129,15 @@ public final class EFXUtil {
             int genError;
             int testObject = 0;
             try {
-                testObject = switch (objectType) { // Create object based on type
-                    case EFFECT -> alGenEffects();
-                    case FILTER -> alGenFilters();
-                    default -> throw new IllegalArgumentException("Invalid objectType: " + objectType);
+                switch (objectType) { // Create object based on type
+                    case EFFECT:
+                        testObject = alGenEffects();
+                        break;
+                    case FILTER:
+                        testObject = alGenFilters();
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Invalid objectType: " + objectType);
                 };
                 genError = alGetError();
             } catch (OpenALException debugBuildException) {
@@ -152,9 +157,14 @@ public final class EFXUtil {
                 int setError;
                 try {
                     switch (objectType) { // Set based on object type
-                        case EFFECT -> alEffecti(testObject, AL_EFFECT_TYPE, typeValue);
-                        case FILTER -> alFilteri(testObject, AL_FILTER_TYPE, typeValue);
-                        default -> throw new IllegalArgumentException("Invalid objectType: " + objectType);
+                        case EFFECT:
+                            alEffecti(testObject, AL_EFFECT_TYPE, typeValue);
+                            break;
+                        case FILTER:
+                            alFilteri(testObject, AL_FILTER_TYPE, typeValue);
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Invalid objectType: " + objectType);
                     }
                     setError = alGetError();
                 } catch (OpenALException debugBuildException) {
@@ -170,9 +180,14 @@ public final class EFXUtil {
                 // Cleanup
                 try {
                     switch (objectType) { // Set based on object type
-                        case EFFECT -> alDeleteEffects(testObject);
-                        case FILTER -> alDeleteFilters(testObject);
-                        default -> throw new IllegalArgumentException("Invalid objectType: " + objectType);
+                        case EFFECT:
+                            alDeleteEffects(testObject);
+                            break;
+                        case FILTER:
+                            alDeleteFilters(testObject);
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Invalid objectType: " + objectType);
                     }
                 } catch (OpenALException debugBuildException) {
                     // Don't care about cleanup errors.

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -221,11 +221,20 @@ public class Display {
                         KeyEvent.getKeyText(KeyCodes.lwjglToAwt(KeyCodes.glfwToLwjgl(key))),
                         (key >= 32 && key < 127) ? ((char) key) : '?');
                 }
-                final InputEvents.KeyAction enumAction = switch (action) {
-                    case GLFW_PRESS -> InputEvents.KeyAction.PRESSED;
-                    case GLFW_RELEASE -> InputEvents.KeyAction.RELEASED;
-                    case GLFW_REPEAT -> InputEvents.KeyAction.REPEATED;
-                    default -> InputEvents.KeyAction.PRESSED;
+                InputEvents.KeyAction enumAction = null;
+                switch (action) {
+                    case GLFW_PRESS:
+                        enumAction = InputEvents.KeyAction.PRESSED;
+                        break;
+                    case GLFW_RELEASE:
+                        enumAction = InputEvents.KeyAction.RELEASED;
+                        break;
+                    case GLFW_REPEAT:
+                        enumAction = InputEvents.KeyAction.REPEATED;
+                        break;
+                    default:
+                        enumAction = InputEvents.KeyAction.PRESSED;
+                        break;
                 };
                 InputEvents.injectKeyEvent(
                     new InputEvents.KeyEvent(
@@ -304,12 +313,23 @@ public class Display {
                         Keyboard.addGlfwKeyEvent(window, key, scancode, action, mods, '\0');
                     }
                 } else { // Other key with no char event associated
-                    char mappedChar = switch (key) {
-                        case GLFW_KEY_ENTER -> 0x0D;
-                        case GLFW_KEY_ESCAPE -> 0x1B;
-                        case GLFW_KEY_TAB -> 0x09;
-                        case GLFW_KEY_BACKSPACE -> 0x08;
-                        default -> '\0';
+                    char mappedChar = '\0';
+                    switch (key) {
+                        case GLFW_KEY_ENTER:
+                            mappedChar = 0x0D;
+                            break;
+                        case GLFW_KEY_ESCAPE:
+                            mappedChar = 0x1B;
+                            break;
+                        case GLFW_KEY_TAB:
+                            mappedChar = 0x09;
+                            break;
+                        case GLFW_KEY_BACKSPACE:
+                            mappedChar = 0x08;
+                            break;
+                        default:
+                            mappedChar = '\0';
+                            break;
                     };
                     Keyboard.addGlfwKeyEvent(window, key, scancode, action, mods, mappedChar);
                 }
@@ -728,8 +748,44 @@ public class Display {
             vidmode);
     }
 
-    @Desugar
-    public record PositionedGLFWVidMode(int x, int y, Rectangle bounds, long monitorId, GLFWVidMode vidMode) {}
+    public static class PositionedGLFWVidMode {
+        
+        int x, y;
+        
+        Rectangle bounds;
+        
+        long monitorId;
+        
+        GLFWVidMode vidMode;
+        
+        public PositionedGLFWVidMode(int x, int y, Rectangle bounds, long monitorId, GLFWVidMode vidMode) {
+            this.x = x;
+            this.y = y;
+            this.bounds = bounds;
+            this.monitorId = monitorId;
+            this.vidMode = vidMode;
+        }
+        
+        public int x() {
+            return x;
+        }
+        
+        public int y() {
+            return y;
+        }
+        
+        public Rectangle bounds() {
+            return bounds;
+        }
+        
+        public long monitorId() {
+            return monitorId;
+        }
+        
+        public GLFWVidMode vidMode() {
+            return vidMode;
+        }
+    }
 
     public static void setFullscreen(boolean fullscreen) {
         final long window = getWindow();

--- a/src/main/java/org/lwjglx/opengl/DisplayMode.java
+++ b/src/main/java/org/lwjglx/opengl/DisplayMode.java
@@ -83,11 +83,11 @@ public final class DisplayMode {
      * @see java.lang.Object#equals(Object)
      */
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof DisplayMode dm)) {
+        if (obj == null || !(obj instanceof DisplayMode)) {
             return false;
         }
 
-        return dm.width == width && dm.height == height && dm.bpp == bpp && dm.freq == freq;
+        return ((DisplayMode) obj).width == width && ((DisplayMode) obj).height == height && ((DisplayMode) obj).bpp == bpp && ((DisplayMode) obj).freq == freq;
     }
 
     /**

--- a/src/main/java/org/lwjglx/opengl/Util.java
+++ b/src/main/java/org/lwjglx/opengl/Util.java
@@ -40,17 +40,27 @@ public final class Util {
      * Translate a GL error code to a String describing the error
      */
     public static String translateGLErrorString(int error_code) {
-        return switch (error_code) {
-            case GL_NO_ERROR -> "No error";
-            case GL_INVALID_ENUM -> "Invalid enum";
-            case GL_INVALID_VALUE -> "Invalid value";
-            case GL_INVALID_OPERATION -> "Invalid operation";
-            case GL_STACK_OVERFLOW -> "Stack overflow";
-            case GL_STACK_UNDERFLOW -> "Stack underflow";
-            case GL_OUT_OF_MEMORY -> "Out of memory";
-            case GL_TABLE_TOO_LARGE -> "Table too large";
-            case GL_INVALID_FRAMEBUFFER_OPERATION -> "Invalid framebuffer operation";
-            default -> null;
-        };
+        switch (error_code) {
+            case GL_NO_ERROR:
+                return "No error";
+            case GL_INVALID_ENUM:
+                return "Invalid enum";
+            case GL_INVALID_VALUE:
+                return "Invalid value";
+            case GL_INVALID_OPERATION:
+                return "Invalid operation";
+            case GL_STACK_OVERFLOW:
+                return "Stack overflow";
+            case GL_STACK_UNDERFLOW:
+                return "Stack underflow";
+            case GL_OUT_OF_MEMORY:
+                return "Out of memory";
+            case GL_TABLE_TOO_LARGE:
+                return "Table too large";
+            case GL_INVALID_FRAMEBUFFER_OPERATION:
+                return "Invalid framebuffer operation";
+            default:
+                return null;
+        }
     }
 }

--- a/src/main/java/org/lwjglx/util/Color.java
+++ b/src/main/java/org/lwjglx/util/Color.java
@@ -411,35 +411,41 @@ public final class Color implements ReadableColor, Serializable, WritableColor {
             float f6 = brightness * (1.0F - saturation * f4);
             float f7 = brightness * (1.0F - saturation * (1.0F - f4));
             switch ((int) f3) {
-                case 0 -> {
+                case 0: {
                     red = (byte) (brightness * 255F + 0.5F);
                     green = (byte) (f7 * 255F + 0.5F);
                     blue = (byte) (f5 * 255F + 0.5F);
+                    break;
                 }
-                case 1 -> {
+                case 1: {
                     red = (byte) (f6 * 255F + 0.5F);
                     green = (byte) (brightness * 255F + 0.5F);
                     blue = (byte) (f5 * 255F + 0.5F);
+                    break;
                 }
-                case 2 -> {
+                case 2: {
                     red = (byte) (f5 * 255F + 0.5F);
                     green = (byte) (brightness * 255F + 0.5F);
                     blue = (byte) (f7 * 255F + 0.5F);
+                    break;
                 }
-                case 3 -> {
+                case 3: {
                     red = (byte) (f5 * 255F + 0.5F);
                     green = (byte) (f6 * 255F + 0.5F);
                     blue = (byte) (brightness * 255F + 0.5F);
+                    break;
                 }
-                case 4 -> {
+                case 4: {
                     red = (byte) (f7 * 255F + 0.5F);
                     green = (byte) (f5 * 255F + 0.5F);
                     blue = (byte) (brightness * 255F + 0.5F);
+                    break;
                 }
-                case 5 -> {
+                case 5: {
                     red = (byte) (brightness * 255F + 0.5F);
                     green = (byte) (f5 * 255F + 0.5F);
                     blue = (byte) (f6 * 255F + 0.5F);
+                    break;
                 }
             }
         }

--- a/src/main/java/org/lwjglx/util/Dimension.java
+++ b/src/main/java/org/lwjglx/util/Dimension.java
@@ -74,8 +74,8 @@ public final class Dimension implements Serializable, ReadableDimension, Writabl
      * Checks whether two dimension objects have equal values.
      */
     public boolean equals(Object obj) {
-        if (obj instanceof ReadableDimension d) {
-            return (width == d.getWidth()) && (height == d.getHeight());
+        if (obj instanceof ReadableDimension) {
+            return (width == ((ReadableDimension) obj).getWidth()) && (height == ((ReadableDimension) obj).getHeight());
         }
         return false;
     }

--- a/src/main/java/org/lwjglx/util/Point.java
+++ b/src/main/java/org/lwjglx/util/Point.java
@@ -110,8 +110,8 @@ public final class Point implements ReadablePoint, WritablePoint, Serializable {
      *         values; <code>false</code> otherwise
      */
     public boolean equals(Object obj) {
-        if (obj instanceof Point pt) {
-            return (x == pt.x) && (y == pt.y);
+        if (obj instanceof Point) {
+            return (x == ((Point) obj).x) && (y == ((Point) obj).y);
         }
         return super.equals(obj);
     }

--- a/src/main/java/org/lwjglx/util/Rectangle.java
+++ b/src/main/java/org/lwjglx/util/Rectangle.java
@@ -455,8 +455,8 @@ public final class Rectangle implements ReadableRectangle, WritableRectangle, Se
      * @return <code>true</code> if the objects are equal; <code>false</code> otherwise.
      */
     public boolean equals(Object obj) {
-        if (obj instanceof Rectangle r) {
-            return ((x == r.x) && (y == r.y) && (width == r.width) && (height == r.height));
+        if (obj instanceof Rectangle) {
+            return ((x == ((Rectangle) obj).x) && (y == ((Rectangle) obj).y) && (width == ((Rectangle) obj).width) && (height == ((Rectangle) obj).height));
         }
         return super.equals(obj);
     }

--- a/src/main/java/org/lwjglx/util/glu/Disk.java
+++ b/src/main/java/org/lwjglx/util/glu/Disk.java
@@ -65,7 +65,7 @@ public class Disk extends Quadric {
         dr = (outerRadius - innerRadius) / loops;
 
         switch (super.drawStyle) {
-            case GLU_FILL -> {
+            case GLU_FILL: {
                 /*
                  * texture of a gluDisk is a cut out of the texture unit square x, y in [-outerRadius, +outerRadius]; s,
                  * t in [0, 1] (linear mapping)
@@ -109,8 +109,9 @@ public class Disk extends Quadric {
                     }
                     r1 = r2;
                 }
+                return;
             }
-            case GLU_LINE -> {
+            case GLU_LINE: {
                 int l, s;
                 /* draw loops */
                 for (l = 0; l <= loops; l++) {
@@ -134,8 +135,9 @@ public class Disk extends Quadric {
                     }
                     glEnd();
                 }
+                return;
             }
-            case GLU_POINT -> {
+            case GLU_POINT: {
                 int s;
                 glBegin(GL_POINTS);
                 for (s = 0; s < slices; s++) {
@@ -149,8 +151,9 @@ public class Disk extends Quadric {
                     }
                 }
                 glEnd();
+                return;
             }
-            case GLU_SILHOUETTE -> {
+            case GLU_SILHOUETTE: {
                 if (innerRadius != 0.0) {
                     float a;
                     glBegin(GL_LINE_LOOP);
@@ -171,8 +174,9 @@ public class Disk extends Quadric {
                     }
                     glEnd();
                 }
+                return;
             }
-            default -> {
+            default: {
                 return;
             }
         }

--- a/src/main/java/org/lwjglx/util/glu/GLU.java
+++ b/src/main/java/org/lwjglx/util/glu/GLU.java
@@ -368,12 +368,16 @@ public class GLU {
     }
 
     public static String gluErrorString(int error_code) {
-        return switch (error_code) {
-            case GLU_INVALID_ENUM -> "Invalid enum (glu)";
-            case GLU_INVALID_VALUE -> "Invalid value (glu)";
-            case GLU_OUT_OF_MEMORY -> "Out of memory (glu)";
-            default -> Util.translateGLErrorString(error_code);
-        };
+        switch (error_code) {
+            case GLU_INVALID_ENUM:
+                return "Invalid enum (glu)";
+            case GLU_INVALID_VALUE:
+                return "Invalid value (glu)";
+            case GLU_OUT_OF_MEMORY:
+                return "Out of memory (glu)";
+            default:
+                return Util.translateGLErrorString(error_code);
+        }
     }
 
     public static GLUtessellator gluNewTess() {

--- a/src/main/java/org/lwjglx/util/glu/MipMap.java
+++ b/src/main/java/org/lwjglx/util/glu/MipMap.java
@@ -142,7 +142,7 @@ public class MipMap extends Util {
 
         // Determine bytes per input type
         switch (typein) {
-            case GL_UNSIGNED_BYTE -> {
+            case GL_UNSIGNED_BYTE: {
                 if (!stbir_resize_uint8_srgb(
                     dataIn,
                     widthIn,
@@ -157,8 +157,9 @@ public class MipMap extends Util {
                     0)) {
                     throw new RuntimeException("Couldn't resize image with stbir");
                 }
+                break;
             }
-            case GL_FLOAT -> {
+            case GL_FLOAT: {
                 if (!stbir_resize_float(
                     dataIn.asFloatBuffer(),
                     widthIn,
@@ -171,8 +172,9 @@ public class MipMap extends Util {
                     components)) {
                     throw new RuntimeException("Couldn't resize image with stbir");
                 }
+                break;
             }
-            default -> {
+            default: {
                 return GL_INVALID_ENUM;
             }
         }

--- a/src/main/java/org/lwjglx/util/glu/PartialDisk.java
+++ b/src/main/java/org/lwjglx/util/glu/PartialDisk.java
@@ -121,7 +121,7 @@ public class PartialDisk extends Quadric {
         }
 
         switch (super.drawStyle) {
-            case GLU_FILL -> {
+            case GLU_FILL: {
                 if (innerRadius == .0f) {
                     finish = loops - 1;
                     /* Triangle strip for inner polygons */
@@ -188,8 +188,9 @@ public class PartialDisk extends Quadric {
                     }
                     glEnd();
                 }
+                return;
             }
-            case GLU_POINT -> {
+            case GLU_POINT: {
                 glBegin(GL_POINTS);
                 for (i = 0; i < slices2; i++) {
                     sintemp = sinCache[i];
@@ -206,8 +207,9 @@ public class PartialDisk extends Quadric {
                     }
                 }
                 glEnd();
+                return;
             }
-            case GLU_LINE -> {
+            case GLU_LINE: {
                 if (innerRadius == outerRadius) {
                     glBegin(GL_LINE_STRIP);
 
@@ -252,8 +254,9 @@ public class PartialDisk extends Quadric {
                     }
                     glEnd();
                 }
+                return;
             }
-            case GLU_SILHOUETTE -> {
+            case GLU_SILHOUETTE: {
                 if (sweepAngle < 360.0f) {
                     for (i = 0; i <= slices; i += slices) {
                         sintemp = sinCache[i];
@@ -287,8 +290,9 @@ public class PartialDisk extends Quadric {
                     glEnd();
                     if (innerRadius == outerRadius) break;
                 }
+                return;
             }
-            default -> {}
+            default: {}
         }
     }
 }

--- a/src/main/java/org/lwjglx/util/glu/Util.java
+++ b/src/main/java/org/lwjglx/util/glu/Util.java
@@ -93,13 +93,27 @@ public class Util {
      */
     protected static int compPerPix(int format) {
         /* Determine number of components per pixel */
-        return switch (format) {
-            case GL_COLOR_INDEX, GL_STENCIL_INDEX, GL_DEPTH_COMPONENT, GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA, GL_LUMINANCE -> 1;
-            case GL_LUMINANCE_ALPHA -> 2;
-            case GL_RGB, GL_BGR -> 3;
-            case GL_RGBA, GL_BGRA -> 4;
-            default -> -1;
-        };
+        switch (format) {
+            case GL_COLOR_INDEX:
+            case GL_STENCIL_INDEX:
+            case GL_DEPTH_COMPONENT:
+            case GL_RED:
+            case GL_GREEN:
+            case GL_BLUE:
+            case GL_ALPHA:
+            case GL_LUMINANCE:
+                return 1;
+            case GL_LUMINANCE_ALPHA:
+                return 2;
+            case GL_RGB:
+            case GL_BGR:
+                return 3;
+            case GL_RGBA:
+            case GL_BGRA:
+                return 4;
+            default:
+                return -1;
+        }
     }
 
     /**
@@ -107,12 +121,17 @@ public class Util {
      * @return Index of the alpha channel, or -1 if not found
      */
     protected static int formatAlphaIndex(int format) {
-        return switch (format) {
-            case GL_ALPHA -> 0;
-            case GL_LUMINANCE_ALPHA -> 1;
-            case GL_RGBA, GL_BGRA -> 3;
-            default -> -1;
-        };
+        switch (format) {
+            case GL_ALPHA:
+                return 0;
+            case GL_LUMINANCE_ALPHA:
+                return 1;
+            case GL_RGBA:
+            case GL_BGRA:
+                return 3;
+            default:
+                return -1;
+        }
     }
 
     /**
@@ -154,25 +173,66 @@ public class Util {
     protected static int bytesPerPixel(int format, int type) {
         int n, m;
 
-        n = switch (format) {
-            case GL_COLOR_INDEX, GL_STENCIL_INDEX, GL_DEPTH_COMPONENT, GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA, GL_LUMINANCE -> 1;
-            case GL_LUMINANCE_ALPHA -> 2;
-            case GL_RGB, GL_BGR -> 3;
-            case GL_RGBA, GL_BGRA -> 4;
-            default -> 0;
-        };
+        n = 0;
+        
+        switch (format) {
+            case GL_COLOR_INDEX:
+            case GL_STENCIL_INDEX:
+            case GL_DEPTH_COMPONENT:
+            case GL_RED:
+            case GL_GREEN:
+            case GL_BLUE:
+            case GL_ALPHA:
+            case GL_LUMINANCE:
+                n = 1;
+                break;
+            case GL_LUMINANCE_ALPHA:
+                n = 2;
+                break;
+            case GL_RGB:
+            case GL_BGR:
+                n = 3;
+                break;
+            case GL_RGBA:
+            case GL_BGRA:
+                n = 4;
+                break;
+            default:
+                n = 0;
+                break;
+        }
 
-        m = switch (type) {
-            case GL_UNSIGNED_BYTE -> 1;
-            case GL_BYTE -> 1;
-            case GL_BITMAP -> 1;
-            case GL_UNSIGNED_SHORT -> 2;
-            case GL_SHORT -> 2;
-            case GL_UNSIGNED_INT -> 4;
-            case GL_INT -> 4;
-            case GL_FLOAT -> 4;
-            default -> 0;
-        };
+        m = 0;
+        
+        switch (type) {
+            case GL_UNSIGNED_BYTE:
+                m = 1;
+                break;
+            case GL_BYTE:
+                m = 1;
+                break;
+            case GL_BITMAP:
+                m = 1;
+                break;
+            case GL_UNSIGNED_SHORT:
+                m = 2;
+                break;
+            case GL_SHORT:
+                m = 2;
+                break;
+            case GL_UNSIGNED_INT:
+                m = 4;
+                break;
+            case GL_INT:
+                m = 4;
+                break;
+            case GL_FLOAT:
+                m = 4;
+                break;
+            default:
+                m = 0;
+                break;
+        }
 
         return n * m;
     }

--- a/src/main/java/org/lwjglx/util/glu/tessellation/GLUtessellatorImpl.java
+++ b/src/main/java/org/lwjglx/util/glu/tessellation/GLUtessellatorImpl.java
@@ -211,11 +211,15 @@ public class GLUtessellatorImpl implements GLUtessellator {
                 if (windingRule != value) break; /* not an integer */
 
                 switch (windingRule) {
-                    case GLU_TESS_WINDING_ODD, GLU_TESS_WINDING_NONZERO, GLU_TESS_WINDING_POSITIVE, GLU_TESS_WINDING_NEGATIVE, GLU_TESS_WINDING_ABS_GEQ_TWO -> {
+                    case GLU_TESS_WINDING_ODD:
+                    case GLU_TESS_WINDING_NONZERO:
+                    case GLU_TESS_WINDING_POSITIVE:
+                    case GLU_TESS_WINDING_NEGATIVE:
+                    case GLU_TESS_WINDING_ABS_GEQ_TWO: {
                         this.windingRule = windingRule;
                         return;
                     }
-                    default -> {}
+                    default: {}
                 }
 
             case GLU_TESS_BOUNDARY_ONLY:
@@ -232,25 +236,29 @@ public class GLUtessellatorImpl implements GLUtessellator {
     /* Returns tessellator property */
     public void gluGetTessProperty(int which, double[] value, int value_offset) {
         switch (which) {
-            case GLU_TESS_TOLERANCE -> {
+            case GLU_TESS_TOLERANCE: {
                 /* tolerance should be in range [0..1] */
                 assert (0.0 <= relTolerance && relTolerance <= 1.0);
                 value[value_offset] = relTolerance;
+                break;
             }
-            case GLU_TESS_WINDING_RULE -> {
+            case GLU_TESS_WINDING_RULE: {
                 assert (windingRule == GLU_TESS_WINDING_ODD || windingRule == GLU_TESS_WINDING_NONZERO
                     || windingRule == GLU_TESS_WINDING_POSITIVE
                     || windingRule == GLU_TESS_WINDING_NEGATIVE
                     || windingRule == GLU_TESS_WINDING_ABS_GEQ_TWO);
                 value[value_offset] = windingRule;
+                break;
             }
-            case GLU_TESS_BOUNDARY_ONLY -> {
+            case GLU_TESS_BOUNDARY_ONLY: {
                 assert (boundaryOnly == true || boundaryOnly == false);
                 value[value_offset] = boundaryOnly ? 1 : 0;
+                break;
             }
-            default -> {
+            default: {
                 value[value_offset] = 0.0;
                 callErrorOrErrorData(GLU_INVALID_ENUM);
+                break;
             }
         }
     } /* gluGetTessProperty() */
@@ -263,15 +271,15 @@ public class GLUtessellatorImpl implements GLUtessellator {
 
     public void gluTessCallback(int which, GLUtessellatorCallback aCallback) {
         switch (which) {
-            case GLU_TESS_BEGIN -> {
+            case GLU_TESS_BEGIN: {
                 callBegin = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_BEGIN_DATA -> {
+            case GLU_TESS_BEGIN_DATA: {
                 callBeginData = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_EDGE_FLAG -> {
+            case GLU_TESS_EDGE_FLAG: {
                 callEdgeFlag = aCallback == null ? NULL_CB : aCallback;
                 /*
                  * If the client wants boundary edges to be flagged, we render everything as separate triangles (no
@@ -280,7 +288,7 @@ public class GLUtessellatorImpl implements GLUtessellator {
                 flagBoundary = aCallback != null;
                 return;
             }
-            case GLU_TESS_EDGE_FLAG_DATA -> {
+            case GLU_TESS_EDGE_FLAG_DATA: {
                 callEdgeFlagData = callBegin = aCallback == null ? NULL_CB : aCallback;
                 /*
                  * If the client wants boundary edges to be flagged, we render everything as separate triangles (no
@@ -289,42 +297,42 @@ public class GLUtessellatorImpl implements GLUtessellator {
                 flagBoundary = (aCallback != null);
                 return;
             }
-            case GLU_TESS_VERTEX -> {
+            case GLU_TESS_VERTEX: {
                 callVertex = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_VERTEX_DATA -> {
+            case GLU_TESS_VERTEX_DATA: {
                 callVertexData = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_END -> {
+            case GLU_TESS_END: {
                 callEnd = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_END_DATA -> {
+            case GLU_TESS_END_DATA: {
                 callEndData = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_ERROR -> {
+            case GLU_TESS_ERROR: {
                 callError = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_ERROR_DATA -> {
+            case GLU_TESS_ERROR_DATA: {
                 callErrorData = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_COMBINE -> {
+            case GLU_TESS_COMBINE: {
                 callCombine = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
-            case GLU_TESS_COMBINE_DATA -> {
+            case GLU_TESS_COMBINE_DATA: {
                 callCombineData = aCallback == null ? NULL_CB : aCallback;
                 return;
             }
             // case GLU_TESS_MESH:
             // callMesh = aCallback == null ? NULL_CB : aCallback;
             // return;
-            default -> {
+            default: {
                 callErrorOrErrorData(GLU_INVALID_ENUM);
                 return;
             }

--- a/src/main/java/org/lwjglx/util/glu/tessellation/Sweep.java
+++ b/src/main/java/org/lwjglx/util/glu/tessellation/Sweep.java
@@ -205,19 +205,19 @@ class Sweep {
 
     static boolean IsWindingInside(GLUtessellatorImpl tess, int n) {
         switch (tess.windingRule) {
-            case GLU_TESS_WINDING_ODD -> {
+            case GLU_TESS_WINDING_ODD: {
                 return (n & 1) != 0;
             }
-            case GLU_TESS_WINDING_NONZERO -> {
+            case GLU_TESS_WINDING_NONZERO: {
                 return (n != 0);
             }
-            case GLU_TESS_WINDING_POSITIVE -> {
+            case GLU_TESS_WINDING_POSITIVE: {
                 return (n > 0);
             }
-            case GLU_TESS_WINDING_NEGATIVE -> {
+            case GLU_TESS_WINDING_NEGATIVE: {
                 return (n < 0);
             }
-            case GLU_TESS_WINDING_ABS_GEQ_TWO -> {
+            case GLU_TESS_WINDING_ABS_GEQ_TWO: {
                 return (n >= 2) || (n <= -2);
             }
         }

--- a/src/relauncherStub/java/me/eigenraven/lwjgl3ify/relauncherstub/GraphicalConsole.java
+++ b/src/relauncherStub/java/me/eigenraven/lwjgl3ify/relauncherstub/GraphicalConsole.java
@@ -45,7 +45,7 @@ public class GraphicalConsole {
 
         final BufferedReader reader;
         final JTextArea guiLog;
-        final static String LINE_SEPARATOR = System.lineSeparator();
+        final String LINE_SEPARATOR = System.lineSeparator();
 
         StreamToQueueAdapter(InputStream stream, JTextArea guiLog) {
             reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
@@ -154,9 +154,7 @@ public class GraphicalConsole {
 
             final Thread processDeathAwaiter = new Thread(() -> {
                 try {
-                    final Process terminated = process.onExit()
-                        .get();
-                    final int exitCode = terminated.exitValue();
+                    final int exitCode = process.waitFor();
                     invokeOnSwingThread(false, () -> {
                         killButton.setEnabled(false);
                         try {
@@ -171,7 +169,7 @@ public class GraphicalConsole {
                         }
                     });
 
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (InterruptedException e) {
                     // ignored
                 }
             }, "death awaiter");
@@ -191,11 +189,7 @@ public class GraphicalConsole {
         } catch (InterruptedException e) {
             // cancelled
         } catch (InvocationTargetException e) {
-            if (e.getCause() instanceof RuntimeException re) {
-                throw re;
-            } else {
-                throw new RuntimeException(e);
-            }
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/relauncherStub/java/me/eigenraven/lwjgl3ify/relauncherstub/RelauncherStubMain.java
+++ b/src/relauncherStub/java/me/eigenraven/lwjgl3ify/relauncherstub/RelauncherStubMain.java
@@ -1,5 +1,10 @@
 package me.eigenraven.lwjgl3ify.relauncherstub;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -23,8 +28,35 @@ public class RelauncherStubMain {
         final boolean showConsole = Boolean.parseBoolean(args[1]);
         final String javaBinary = args[2];
         final String javaArgFile = args[3];
-        final String[] javaCmdline = new String[] { javaBinary, "@" + javaArgFile };
-        final ProcessHandle myProcess = ProcessHandle.current();
+        File file = new File(javaArgFile);
+        FileInputStream fis = new FileInputStream(file);
+        byte[] b = new byte[1024];
+        StringBuilder sb = new StringBuilder();
+        int r = 0;
+        while ((r = fis.read(b)) != -1) {
+            sb.append(new String(Arrays.copyOf(b, r)));
+        }
+        String[] lines = sb.toString().split("\\r?\\n");
+        ArrayList<String> arr = new ArrayList<String>();
+        arr.add(javaBinary);
+        for (String line : lines) {
+            String line2 = line.substring(1);
+            line2 = line2.substring(0, line2.length() - 1);
+            //if (line.contains("-Dfile.encoding=UTF-8")) continue;
+            if (line.contains("--add-opens")) continue;
+            if (line.contains("java.base/")) continue;
+            if (line.contains("java.desktop/")) continue;
+            if (line.contains("java.sql.rowset/")) continue;
+            if (line.contains("jdk.dynalink/")) continue;
+            if (line.contains("jdk.naming.dns/")) continue;
+            if (line.contains("-Djava.security.manager=allow")) continue;
+            //sb2.append(line2 + " ");
+            System.out.println(line2);
+            arr.add(line2);
+        }
+        //final String[] javaCmdline = new String[] { javaBinary, "@" + javaArgFile };
+        final String[] javaCmdline = arr.toArray(new String[0]);
+        /*final ProcessHandle myProcess = ProcessHandle.current();
         final ProcessHandle parentProcess = ProcessHandle.of(parentPid)
             .orElse(
                 myProcess.parent()
@@ -35,10 +67,10 @@ public class RelauncherStubMain {
             // Wait for parent to fully exit
             parentProcess.onExit()
                 .get();
-        } else {
+        } else {*/
             // Wait a little bit, hopefully the parent exits in this time (not finding the parent shouldn't happen)
             Thread.sleep(1000);
-        }
+        //}
 
         final ProcessBuilder childBuilder = new ProcessBuilder(javaCmdline);
 
@@ -48,8 +80,14 @@ public class RelauncherStubMain {
             final Process child = childBuilder.start();
             new GraphicalConsole(child.getInputStream(), child.getErrorStream(), child);
         } else {
-            childBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
-            childBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+            //childBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+            //childBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+            File NULL_FILE = new File(
+                   (System.getProperty("os.name")
+                              .startsWith("Windows") ? "NUL" : "/dev/null")
+            );
+            childBuilder.redirectOutput(NULL_FILE);
+            childBuilder.redirectError(NULL_FILE);
             childBuilder.start();
         }
 


### PR DESCRIPTION
please, instead of closing this pr immediately, i want you to actually think about how you can implement java 8 support upstream instead of outright not supporting it. i went from 25fps to 80fps by switching from https://adoptium.net/temurin/releases/ jdk 17 to oracle jdk8u231 with this mod. its not a want, its a necessity. for a version of minecraft which is expected to get high performance, it should be possible to use java 8 with this mod which is undoubtedly much faster then java 17

my laptop is a 2017 macbook pro and the bootcamp drivers for windows dont let me play vanilla 1.7.10 on this laptop, it spazzes out. this mod allows me to play 1.7.10 on this laptop. having java 8 support is a necessity to me. 

if you could please implement the same or similar changes upstream to allow users to choose between java 8 or java 17 for example, id greatly appreciate that. thank you

![image](https://github.com/user-attachments/assets/fb7a8ed8-94f7-4505-b643-94e712a19132)
