### PR TITLE
Reduce buffer allocations

### DIFF
--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -1,9 +1,12 @@
 package org.lwjglx.openal;
 
+import static org.lwjgl.system.MemoryStack.stackPush;
+
 import java.nio.IntBuffer;
 
 import org.lwjgl.openal.ALC10;
 import org.lwjgl.openal.ALCCapabilities;
+import org.lwjgl.system.MemoryStack;
 import org.lwjglx.BufferUtils;
 import org.lwjglx.LWJGLException;
 import org.lwjglx.Sys;
@@ -32,50 +35,52 @@ public class AL {
 
     public static void create(String deviceArguments, int contextFrequency, int contextRefresh,
         boolean contextSynchronized, boolean openDevice) throws LWJGLException {
-        IntBuffer attribs = BufferUtils.createIntBuffer(16);
+        try (MemoryStack stack = stackPush()) {
+            IntBuffer attribs = stack.mallocInt(16);
 
-        attribs.put(org.lwjgl.openal.ALC10.ALC_FREQUENCY);
-        attribs.put(contextFrequency);
+            attribs.put(org.lwjgl.openal.ALC10.ALC_FREQUENCY);
+            attribs.put(contextFrequency);
 
-        attribs.put(org.lwjgl.openal.ALC10.ALC_REFRESH);
-        attribs.put(contextRefresh);
+            attribs.put(org.lwjgl.openal.ALC10.ALC_REFRESH);
+            attribs.put(contextRefresh);
 
-        attribs.put(org.lwjgl.openal.ALC10.ALC_SYNC);
-        attribs.put(contextSynchronized ? org.lwjgl.openal.ALC10.ALC_TRUE : org.lwjgl.openal.ALC10.ALC_FALSE);
+            attribs.put(org.lwjgl.openal.ALC10.ALC_SYNC);
+            attribs.put(contextSynchronized ? org.lwjgl.openal.ALC10.ALC_TRUE : org.lwjgl.openal.ALC10.ALC_FALSE);
 
-        /////////////////////////////////////////////
-        // HRTF
-        if (!Config.OPENAL_ENABLE_HRTF) {
-            attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_SOFT);
-            attribs.put(org.lwjgl.openal.ALC10.ALC_FALSE);
+            /////////////////////////////////////////////
+            // HRTF
+            if (!Config.OPENAL_ENABLE_HRTF) {
+                attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_SOFT);
+                attribs.put(org.lwjgl.openal.ALC10.ALC_FALSE);
 
-            attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_ID_SOFT);
+                attribs.put(org.lwjgl.openal.SOFTHRTF.ALC_HRTF_ID_SOFT);
+                attribs.put(0);
+            }
+            /////////////////////////////////////////////
+
+            attribs.put(org.lwjgl.openal.EXTEfx.ALC_MAX_AUXILIARY_SENDS);
+            attribs.put(4);
+
             attribs.put(0);
+            attribs.flip();
+
+            String defaultDevice = org.lwjgl.openal.ALC10.alcGetString(0, ALC10.ALC_DEFAULT_DEVICE_SPECIFIER);
+
+            long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(defaultDevice);
+
+            if (deviceHandle == 0) {
+                throw new LWJGLException("Could not open ALC device");
+            }
+
+            alcDevice = new ALCdevice(deviceHandle);
+            final ALCCapabilities deviceCaps = org.lwjgl.openal.ALC.createCapabilities(deviceHandle);
+
+            long contextHandle = org.lwjgl.openal.ALC10.alcCreateContext(AL.getDevice().device, attribs);
+            alcContext = new ALCcontext(contextHandle);
+            org.lwjgl.openal.ALC10.alcMakeContextCurrent(contextHandle);
+            org.lwjgl.openal.AL.createCapabilities(deviceCaps);
+            created = true;
         }
-        /////////////////////////////////////////////
-
-        attribs.put(org.lwjgl.openal.EXTEfx.ALC_MAX_AUXILIARY_SENDS);
-        attribs.put(4);
-
-        attribs.put(0);
-        attribs.flip();
-
-        String defaultDevice = org.lwjgl.openal.ALC10.alcGetString(0, ALC10.ALC_DEFAULT_DEVICE_SPECIFIER);
-
-        long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(defaultDevice);
-
-        if (deviceHandle == 0) {
-            throw new LWJGLException("Could not open ALC device");
-        }
-
-        alcDevice = new ALCdevice(deviceHandle);
-        final ALCCapabilities deviceCaps = org.lwjgl.openal.ALC.createCapabilities(deviceHandle);
-
-        long contextHandle = org.lwjgl.openal.ALC10.alcCreateContext(AL.getDevice().device, attribs);
-        alcContext = new ALCcontext(contextHandle);
-        org.lwjgl.openal.ALC10.alcMakeContextCurrent(contextHandle);
-        org.lwjgl.openal.AL.createCapabilities(deviceCaps);
-        created = true;
     }
 
     public static boolean isCreated() {

--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -7,7 +7,6 @@ import java.nio.IntBuffer;
 import org.lwjgl.openal.ALC10;
 import org.lwjgl.openal.ALCCapabilities;
 import org.lwjgl.system.MemoryStack;
-import org.lwjglx.BufferUtils;
 import org.lwjglx.LWJGLException;
 import org.lwjglx.Sys;
 

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -661,8 +661,8 @@ public class Display {
                     GLFWImage.create()
                         .set(dimension, dimension, nativeBuffers[icon]));
             }
+            GLFW.glfwSetWindowIcon(getWindow(), glfwImages);
         }
-        GLFW.glfwSetWindowIcon(getWindow(), glfwImages);
         glfwImages.free();
         return 0;
     }

--- a/src/main/java/org/lwjglx/opengl/GL15x.java
+++ b/src/main/java/org/lwjglx/opengl/GL15x.java
@@ -1,19 +1,23 @@
 package org.lwjglx.opengl;
 
+import static org.lwjgl.system.MemoryStack.stackPush;
+
 import java.nio.ByteBuffer;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opengl.GL15;
+import org.lwjgl.system.MemoryStack;
 
 public class GL15x {
 
     public static ByteBuffer glGetBufferPointer(int target, int pname) {
         int size = GL15.glGetBufferParameteri(target, GL15.GL_BUFFER_SIZE);
+        try (MemoryStack stack = stackPush()) {
+            PointerBuffer pb = stack.mallocPointer(1);
+            GL15.glGetBufferPointerv(target, pname, pb);
 
-        PointerBuffer pb = BufferUtils.createPointerBuffer(1);
-        GL15.glGetBufferPointerv(target, pname, pb);
-
-        return pb.getByteBuffer(0, size);
+            return pb.getByteBuffer(0, size);
+        }
     }
 }

--- a/src/main/java/org/lwjglx/opengl/GL15x.java
+++ b/src/main/java/org/lwjglx/opengl/GL15x.java
@@ -4,7 +4,6 @@ import static org.lwjgl.system.MemoryStack.stackPush;
 
 import java.nio.ByteBuffer;
 
-import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opengl.GL15;
 import org.lwjgl.system.MemoryStack;

--- a/src/main/java/org/lwjglx/opengl/GL20x.java
+++ b/src/main/java/org/lwjglx/opengl/GL20x.java
@@ -6,7 +6,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 
-import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;

--- a/src/main/java/org/lwjglx/opengl/GL20x.java
+++ b/src/main/java/org/lwjglx/opengl/GL20x.java
@@ -1,5 +1,7 @@
 package org.lwjglx.opengl;
 
+import static org.lwjgl.system.MemoryStack.stackPush;
+
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
@@ -8,6 +10,7 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
+import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 
 public class GL20x {
@@ -32,18 +35,23 @@ public class GL20x {
 
     public static String glGetActiveAttrib(int program, int index, int maxLength, IntBuffer sizeType) {
         // TODO check if correct
-        IntBuffer type = BufferUtils.createIntBuffer(1);
-        String s = GL20.glGetActiveAttrib(program, index, maxLength, sizeType, type);
-        sizeType.put(type.get(0));
+        String s;
+        try (MemoryStack stack = stackPush()) {
+            IntBuffer type = stack.mallocInt(1);
+            s = GL20.glGetActiveAttrib(program, index, maxLength, sizeType, type);
+            sizeType.put(type.get(0));
+        }
         return s;
     }
 
     public static void glShaderSource(int shader, java.nio.ByteBuffer string) {
-        PointerBuffer strings = BufferUtils.createPointerBuffer(1);
-        IntBuffer lengths = BufferUtils.createIntBuffer(1);
+        try (MemoryStack stack = stackPush()) {
+            PointerBuffer strings = stack.mallocPointer(1);
+            IntBuffer lengths = stack.mallocInt(1);
 
-        strings.put(0, string);
-        lengths.put(0, new String(string.array()).length()); // source.length());
-        org.lwjgl.opengl.GL20.glShaderSource(shader, strings, lengths);
+            strings.put(0, string);
+            lengths.put(0, new String(string.array()).length()); // source.length());
+            org.lwjgl.opengl.GL20.glShaderSource(shader, strings, lengths);
+        }
     }
 }

--- a/src/main/java/org/lwjglx/util/glu/MipMap.java
+++ b/src/main/java/org/lwjglx/util/glu/MipMap.java
@@ -19,12 +19,10 @@ import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.stb.STBImageResize.*;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjglx.util.glu.GLU.*;
-import static org.openjdk.nashorn.internal.objects.NativeError.getStack;
 
 import java.nio.ByteBuffer;
 
 import org.lwjgl.system.MemoryStack;
-import org.lwjglx.BufferUtils;
 
 /**
  * MipMap.java

--- a/src/main/java/org/lwjglx/util/glu/MipMap.java
+++ b/src/main/java/org/lwjglx/util/glu/MipMap.java
@@ -18,12 +18,9 @@ package org.lwjglx.util.glu;
 import static java.nio.ByteBuffer.allocateDirect;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.stb.STBImageResize.*;
-import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjglx.util.glu.GLU.*;
 
 import java.nio.ByteBuffer;
-
-import org.lwjgl.system.MemoryStack;
 
 /**
  * MipMap.java


### PR DESCRIPTION
Replace some buffer allocations with MemoryStack instead. All replacement locations should be contained - I avoided touching methods which returned buffers, as those likely can't be reclaimed once the method exits.