### PR TITLE
Set wayland app_id

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
 rootProject.name = "lwjgl3ify"

--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
@@ -45,6 +45,7 @@ public class Config {
 
     public static String X11_CLASS_NAME = "minecraft";
     public static String COCOA_FRAME_NAME = "minecraft";
+    public static String WAYLAND_APP_ID = "minecraft";
 
     public static String LWJGL3IFY_VERSION = Tags.VERSION;
 

--- a/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/core/Config.java
@@ -148,6 +148,11 @@ public class Config {
             CATEGORY_WINDOW,
             COCOA_FRAME_NAME,
             "OSX-only - identifier used to save and restore the window position and size");
+        WAYLAND_APP_ID = config.getString(
+            "waylandAppId",
+            CATEGORY_WINDOW,
+            WAYLAND_APP_ID,
+            "Linux-only - change the Wayland app id, which is used by your window manager to identify the running application");
 
         INPUT_INVERT_WHEEL = config
             .getBoolean("invertScrollWheel", CATEGORY_INPUT, INPUT_INVERT_WHEEL, "Invert scrolling direction");

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -196,6 +196,7 @@ public class Display {
 
         glfwWindowHintString(GLFW_X11_CLASS_NAME, Config.X11_CLASS_NAME);
         glfwWindowHintString(GLFW_COCOA_FRAME_NAME, Config.COCOA_FRAME_NAME);
+        glfwWindowHintString(GLFW_WAYLAND_APP_ID, Config.WAYLAND_APP_ID);
 
         if (Config.WINDOW_CENTERED) {
             glfwWindowHint(GLFW_POSITION_X, (monitorWidth - mode.getWidth()) / 2);


### PR DESCRIPTION
Thanks to this mod, its possible to run minecraft natively on Wayland, however it does not set the `app_id`, the identifier for windows spawned by an application. Setting this allows Wayland compositors to apply rules to windows (in my case I wanted minecraft to always be floating, not tiled).

This PR simply sets the Wayland app_id via GLFW. The window hint is ignored by other platforms, same as for the X11 and Cocoa hints.

Output from `swaymsg -t get_tree` (which shows information about the current windows)
**Before** (minecraft has no app_id, but prism does):
```
#6: workspace "1"
    #31: con "Prism Launcher 9.1" (xdg_shell, pid: 172749, app_id: "org.prismlauncher.PrismLauncher")
    #32: con "Console window for GT_New_Horizons_2.7.1_Java_17-21 — Prism Launcher 9.1" (xdg_shell, pid: 172749, app_id: "org.prismlauncher.PrismLauncher")
    #47: floating_con "GT: New Horizons 2.7.1" (xdg_shell, pid: 236404)
```

**After** (minecraft has the app_id "minecraft"):
```
#6: workspace "1"
    #31: con "Prism Launcher 9.1" (xdg_shell, pid: 172749, app_id: "org.prismlauncher.PrismLauncher")
    #32: con "Console window for GT_New_Horizons_2.7.1_Java_17-21 — Prism Launcher 9.1" (xdg_shell, pid: 172749, app_id: "org.prismlauncher.PrismLauncher")
    #57: floating_con "GT: New Horizons 2.7.1" (xdg_shell, pid: 268388, app_id: "minecraft")
```

Tested locally, and now sway is able to make my game window float for me on load :smile: 

Ps: I did the `gradlew updateBuildScript` thing because otherwise the build was failing on spotless. I don't understand why, Java development is totally new to me, but that's why those changes are in this too... :upside_down_face: 
