### PR TITLE
Update `version.json` Java version to 21

### DIFF
--- a/launcher-metadata/version.json
+++ b/launcher-metadata/version.json
@@ -116,8 +116,8 @@
     },
     "id": "1.7.10-Forge10.13.4.1614-1.7.10",
     "javaVersion": {
-        "component": "java-runtime-gamma",
-        "majorVersion": 17
+        "component": "java-runtime-delta",
+        "majorVersion": 21
     },
     "libraries": [
         {


### PR DESCRIPTION
Java 21 is currently the newest Java version used by vanilla MC (see https://piston-meta.mojang.com/v1/packages/a3bcba436caa849622fd7e1e5b89489ed6c9ac63/1.21.4.json). This PR updates the `version.json` file to reflect this, so launchers that use this file can use the correct JRE.