### PR TITLE
Fix LogisticsPipes BCCompat with Lwjgl3ify

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/EarlyConfig.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/EarlyConfig.java
@@ -36,7 +36,7 @@ public class EarlyConfig {
         "vswe.stevesfactory.components.ConnectionSet", "vswe.stevesfactory.components.ConnectionOption",
         "ic2.core.init.InternalName", "gregtech.api.enums.Element", "gregtech.api.enums.OrePrefixes",
         "net.minecraft.client.audio.MusicTicker$MusicType", "org.bukkit.Material",
-        "buildcraft.api.transport.IPipeTile.PipeType", "thaumcraft.common.entities.golems.EnumGolemType",
+        "buildcraft.api.transport.IPipeTile$PipeType", "thaumcraft.common.entities.golems.EnumGolemType",
         // Non-GTNH Mods Compat
         // The Lord of the Rings Mod: Legacy
         "net.minecraft.event.HoverEvent$Action",


### PR DESCRIPTION
Fixes:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18853

```
java.lang.RuntimeException: Enum buildcraft.api.transport.IPipeTile$PipeType was not made extensible, add it to lwjgl3ify configs.
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//me.eigenraven.lwjgl3ify.EnumHelper.addEnum(EnumHelper.java:141)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraftforge.common.util.EnumHelper.addEnum(EnumHelper.java)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//logisticspipes.proxy.buildcraft.BuildCraftProxy.getLPPipeType(BuildCraftProxy.java:282)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//logisticspipes.asm.wrapper.generated.BCProxyWrapper.getLPPipeType(.LP|ASM.dynamic:282)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//logisticspipes.pipes.basic.LogisticsTileGenericPipe.getPipeType(LogisticsTileGenericPipe.java:976)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.util.BuildcraftUtil.isValidReceptor(BuildcraftUtil.java:50)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//com.enderio.core.common.util.FluidUtil.getFluidHandler(FluidUtil.java:70)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//com.enderio.core.common.util.FluidUtil.getFluidHandler(FluidUtil.java:63)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//com.enderio.core.common.util.FluidUtil.getFluidHandler(FluidUtil.java:58)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.liquid.AbstractLiquidConduit.getExternalFluidHandler(AbstractLiquidConduit.java:41)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.liquid.AbstractLiquidConduit.getExternalHandler(AbstractLiquidConduit.java:46)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.liquid.AbstractLiquidConduit.canConnectToExternal(AbstractLiquidConduit.java:56)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.AbstractConduit.onNeighborBlockChange(AbstractConduit.java:587)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.liquid.AbstractLiquidConduit.onNeighborBlockChange(AbstractLiquidConduit.java:86)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.AbstractConduit.onNeighborChange(AbstractConduit.java:610)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.TileConduitBundle.onNeighborChange(TileConduitBundle.java:366)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//crazypants.enderio.conduit.BlockConduitBundle.onNeighborChange(BlockConduitBundle.java:920)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.World.func_147453_f(World.java:4047)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.World.func_147455_a(World.java:2749)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.chunk.Chunk.func_150806_e(Chunk.java:881)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.chunk.Chunk.func_150807_a(Chunk.java:686)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.World.setBlock(World.java:492)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.World.func_147465_d(World.java:458)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//logisticspipes.pipes.basic.LogisticsBlockGenericPipe.placePipe(LogisticsBlockGenericPipe.java:925)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//logisticspipes.items.ItemLogisticsPipe.func_77648_a(ItemLogisticsPipe.java:109)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(ForgeHooks.java:512)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.item.ItemStack.func_77943_a(ItemStack.java:128)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.management.ItemInWorldManager.func_73078_a(ItemInWorldManager.java:395)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.NetHandlerPlayServer.func_147346_a(NetHandlerPlayServer.java:573)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.play.client.C08PacketPlayerBlockPlacement.func_148833_a(C08PacketPlayerBlockPlacement.java:65)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.play.client.C08PacketPlayerBlockPlacement.func_148833_a(C08PacketPlayerBlockPlacement.java:110)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:231)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:692)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:335)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:566)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:443)
[20:04:51] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:718)
[20:04:51] [Server thread/FATAL] [LogisticsPipes/]: Disabled BCProxy for Mod: BuildCraft|Transport+BuildCraft|Silicon+BuildCraft|Robotics. Cause was an Exception
```