### PR TITLE
Fix loading corrupted lwjgl3ify-early.json

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/EarlyConfig.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/EarlyConfig.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.gson.Gson;
@@ -91,7 +92,10 @@ public class EarlyConfig {
                 final String earlyConfigContents = new String(
                     Files.readAllBytes(earlyConfigPath),
                     StandardCharsets.UTF_8);
-                cfg = gson.fromJson(earlyConfigContents, ConfigObject.class);
+                ConfigObject parsedConfig = gson.fromJson(earlyConfigContents, ConfigObject.class);
+                if (Objects.nonNull(parsedConfig)) {
+                    cfg = parsedConfig;
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
There were 3 reports of this issue in the #help channel. This can happen when the server runs out of space and a zero-length `lwjgl3ify-early.json` is left behind.

```java
A problem occurred running the Server launcher.java.lang.reflect.InvocationTargetException
        at ...
Caused by: java.lang.NullPointerException: Cannot read field "extensibleEnums" because "cfg" is null
        at System//me.eigenraven.lwjgl3ify.rfb.EarlyConfig.load(EarlyConfig.java:100)
        at System//me.eigenraven.lwjgl3ify.rfb.Lwjgl3ifyRfbPlugin.onConstruction(Lwjgl3ifyRfbPlugin.java:37)
        at com.gtnewhorizons.retrofuturabootstrap.plugin.PluginLoader.initializePlugins(PluginLoader.java:112)
        at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:197)
        at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
        at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
        ... 6 more
```

By the way, is writing this file at startup rather than distributing a config file for it actually  desirable?