### PR TITLE
Remove unsupported jvm versions from the prism launcher manifest

### DIFF
--- a/prism-libraries/patches/net.minecraft.json
+++ b/prism-libraries/patches/net.minecraft.json
@@ -7,12 +7,8 @@
         "url": "https://piston-meta.mojang.com/v1/packages/1863782e33ce7b584fc45b037325a1964e095d3e/1.7.10.json"
     },
     "compatibleJavaMajors": [
-        11,
         17,
-        19,
-        20,
         21,
-        22,
         23,
         24
     ],


### PR DESCRIPTION
- Java 11 is so old we shouldn't recommend it anymore
- Javas 19, 20, 22 are short term support versions that are no longer officially supported

This doesn't remove the actual code support for them, but will throw up a launcher warning about unsupported versions when trying to use them (easily bypassed if needed for testing)