### PR TITLE
Remove -XstartOnFirstThread in version.json for macOS

### DIFF
--- a/launcher-metadata/version.json
+++ b/launcher-metadata/version.json
@@ -55,19 +55,6 @@
                     {
                         "action": "allow",
                         "os": {
-                            "name": "osx"
-                        }
-                    }
-                ],
-                "value": [
-                    "-XstartOnFirstThread"
-                ]
-            },
-            {
-                "rules": [
-                    {
-                        "action": "allow",
-                        "os": {
                             "name": "windows"
                         }
                     }


### PR DESCRIPTION
I'm currently trying to use lwjgl3ify on official launcher on macOS (without relauncher), but it hangs inside `glfwInit()` invocation. In contrast relauncher works perfectly fine.

The culprit seems to be `-XstartOnFirstThread` JVM argument. Removing this starts the game completely normal. I guess `glfw_async` is not compatible with `-XstartOnFirstThread`.

Relauncher is not affected by this problem, as it ignores `jvm` of `version.json`.

## Tested Environments

- macOS 10.13.6, x86_64
- macOS 15.1.1, arm64

## Reference

- https://github.com/LWJGL/lwjgl3/issues/767