### PR TITLE
bump major java versions to j25

### DIFF
--- a/prism-libraries/patches/net.minecraft.json
+++ b/prism-libraries/patches/net.minecraft.json
@@ -10,7 +10,8 @@
         17,
         21,
         23,
-        24
+        24,
+        25
     ],
     "formatVersion": 1,
     "libraries": [


### PR DESCRIPTION
According to @eigenraven it's the only thing needed to get j25 running with lwjgl3ify on clients