### PR TITLE
Properly fix mouse shift bug on retina displays and preserve HiDPI framebuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ whitelist.json
 *.bat
 *.DS_Store
 !gradlew.bat
+layout.json

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,22 +61,22 @@ dependencies {
 
     shadowImplementation("com.github.weisj:darklaf-core:3.0.2")
 
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.4-GTNH:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.19-GTNH:dev')
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev')
     if (addGtForTesting) {
-        runtimeOnlyNonPublishable('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.06:dev')
-        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-700-GTNH:dev")
+        runtimeOnlyNonPublishable('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.62:dev')
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-717-GTNH:dev")
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.0-GTNH:dev")
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.10.17:dev")
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:Railcraft:9.17.0:dev")
-        runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderIO:2.9.26:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderIO:2.10.3:dev")
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:ProjectRed:4.12.0-GTNH:dev") { transitive = false }
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:MrTJPCore:1.3.4:dev")
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeMultipart:1.6.8:dev")
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeRelocation:0.3.4:dev")
         reobfJarConfiguration group: 'curse.maven', name: 'cofh-core-69162', version: '2388750'
         runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.3.7:dev")
-        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.1:dev")
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.3:dev")
     }
     if (addReikaModsForTesting) {
         // DragonAPI

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.44'
 }
 
 rootProject.name = "lwjgl3ify"

--- a/src/main/java/org/lwjglx/input/Mouse.java
+++ b/src/main/java/org/lwjglx/input/Mouse.java
@@ -287,7 +287,7 @@ public class Mouse {
         float inv_scale = 1.0f / Display.getPixelScaleFactor();
         new_x *= inv_scale;
         new_y *= inv_scale;
-        GLFW.glfwSetCursorPos(Display.getWindow(), new_x * inv_scale, new_y * inv_scale);
+        GLFW.glfwSetCursorPos(Display.getWindow(), new_x, new_y);
         // this might lose accuracy, since we just went from fb->screen and this will
         // undo that change. Yay floating point numbers!
         addMoveEvent(new_x, new_y);

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -198,9 +198,6 @@ public class Display {
         glfwWindowHintString(GLFW_COCOA_FRAME_NAME, Config.COCOA_FRAME_NAME);
         glfwWindowHintString(GLFW_WAYLAND_APP_ID, Config.WAYLAND_APP_ID);
 
-        // request a non-hidpi framebuffer on Retina displays on MacOS
-        if (glfwGetPlatform() == GLFW_PLATFORM_COCOA) glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
-
         if (Config.WINDOW_CENTERED) {
             glfwWindowHint(GLFW_POSITION_X, (monitorWidth - mode.getWidth()) / 2);
             glfwWindowHint(GLFW_POSITION_Y, (monitorHeight - mode.getHeight()) / 2);


### PR DESCRIPTION
In previous PR (#231) the `GLFW_COCOA_RETINA_FRAMEBUFFER` was disabled in order to fix mouse position shift when the game releases it (#215), which lead to rendering quality degradation (https://github.com/GTNewHorizons/lwjgl3ify/pull/231#issuecomment-3424040815). This PR fixes that bug while preserving HiDPI framebuffer on retina displays

Also the fix should now work on every system with higher display scaling, not only on macOS

reverts #231, fixes #215