### PR TITLE
feat: Add java-runtime-epsilon to custom prism minecraft json

### DIFF
--- a/prism-libraries/patches/net.minecraft.json
+++ b/prism-libraries/patches/net.minecraft.json
@@ -12,6 +12,7 @@
         25,
         26
     ],
+    "compatibleJavaName": "java-runtime-epsilon",
     "formatVersion": 1,
     "libraries": [
         {


### PR DESCRIPTION
this makes prism autodownload java 25 instead of having to let users manually do it