### PR TITLE
Fix scancode/key mix-up

### DIFF
--- a/src/main/java/org/lwjglx/input/Keyboard.java
+++ b/src/main/java/org/lwjglx/input/Keyboard.java
@@ -262,6 +262,7 @@ public class Keyboard {
             case RELEASED -> KeyState.RELEASE;
             case REPEATED -> KeyState.REPEAT;
         };
+
         addRawKeyEvent(
             new KeyEvent(KeyCodes.sdlScancodeToLwjgl(scancode), KeyCodes.sdlKeycodeToLwjgl(key), c, state, nanoTime));
     }
@@ -326,7 +327,7 @@ public class Keyboard {
     }
 
     public static int lwjgl3ify$getEventKeyNonScancode() {
-        return eventQueue.peek().keyNonScancode;
+        return eventQueue.peek().key;
     }
 
     public static char getEventCharacter() {
@@ -391,22 +392,22 @@ public class Keyboard {
     public static final class KeyEvent {
 
         public int key;
-        public int keyNonScancode;
+        public int scancode;
         public int codepoint;
         public KeyState state;
         public long nano;
         public boolean queueOutOfOrderRelease = false;
 
-        public KeyEvent(int key, int keyNonScancode, int codepoint, KeyState state, long nano) {
+        public KeyEvent(int scancode, int key, int codepoint, KeyState state, long nano) {
             this.key = key;
-            this.keyNonScancode = keyNonScancode;
+            this.scancode = scancode;
             this.codepoint = codepoint;
             this.state = state;
             this.nano = nano;
         }
 
         public KeyEvent copy() {
-            final KeyEvent ev = new KeyEvent(key, keyNonScancode, codepoint, state, nano);
+            final KeyEvent ev = new KeyEvent(key, scancode, codepoint, state, nano);
             ev.queueOutOfOrderRelease = this.queueOutOfOrderRelease;
             return ev;
         }


### PR DESCRIPTION
Fixes #285 

It seems that scancode were treated as actual keys, but if you somehow modify them (Eg. invert caps and esc) the client would not pick-up on this