### PR TITLE
Update Java Version in `version.json`

### DIFF
--- a/launcher-metadata/version.json
+++ b/launcher-metadata/version.json
@@ -116,8 +116,8 @@
     },
     "id": "1.7.10-Forge10.13.4.1614-1.7.10",
     "javaVersion": {
-        "component": "java-runtime-delta",
-        "majorVersion": 21
+        "component": "java-runtime-epsilon",
+        "majorVersion": 25
     },
     "libraries": [
         {


### PR DESCRIPTION
Java 25 is used since Minecraft [26.1-snapshot-1](https://piston-meta.mojang.com/v1/packages/b9345ee364d36ef1c7ec26df6bf99d3e4a4393f5/26.1-snapshot-1.json). We can make use of it too.