### PR TITLE
Fix Chinese IME support for non-TextField GUIs (Signs, Books, Xaero's)

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/Mixins.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/Mixins.java
@@ -23,7 +23,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> Config.MIXIN_STBI_TEXTURE_LOADING)),
     TEXT_FIELD_SDL_INPUT(
         new MixinBuilder()
-            .addClientMixins("game.MixinGuiTextField", "game.MixinGuiScreen")),
+            .addClientMixins("game.MixinGuiTextField", "game.MixinGuiScreen", "game.MixinGuiTextInput")),
     OPEN_URL_WITH_SDL(
         new MixinBuilder()
             .addClientMixins(

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/game/MixinGuiTextInput.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/game/MixinGuiTextInput.java
@@ -1,0 +1,26 @@
+package me.eigenraven.lwjgl3ify.mixins.early.game;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiScreenBook;
+import net.minecraft.client.gui.inventory.GuiEditSign;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import me.eigenraven.lwjgl3ify.client.TextFieldHandler;
+
+@Mixin({ GuiEditSign.class, GuiScreenBook.class })
+public abstract class MixinGuiTextInput extends GuiScreen {
+
+    @Inject(method = "initGui()V", at = @At("HEAD"))
+    private void lwjgl3ify$onInit(CallbackInfo ci) {
+        TextFieldHandler.beginTextInput();
+    }
+
+    @Inject(method = "onGuiClosed()V", at = @At("HEAD"))
+    private void lwjgl3ify$onClose(CallbackInfo ci) {
+        TextFieldHandler.endTextInput(null);
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/late/xaeros/XaerosMinimapScrolling.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/late/xaeros/XaerosMinimapScrolling.java
@@ -1,9 +1,13 @@
 package me.eigenraven.lwjgl3ify.mixins.late.xaeros;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import me.eigenraven.lwjgl3ify.client.TextFieldHandler;
 import xaero.common.gui.GuiAddWaypoint;
 import xaero.common.gui.GuiEntityRadar;
 import xaero.common.gui.GuiTransfer;
@@ -16,5 +20,15 @@ public class XaerosMinimapScrolling {
     @ModifyConstant(method = "handleMouseInput", constant = @Constant(intValue = 120), expect = -1)
     private int lwjgl3ify$rescaledGetEventDWheel(int original) {
         return 1;
+    }
+
+    @Inject(method = "initGui()V", at = @At("HEAD"), remap = false)
+    private void lwjgl3ify$onInit(CallbackInfo ci) {
+        TextFieldHandler.beginTextInput();
+    }
+
+    @Inject(method = "onGuiClosed()V", at = @At("HEAD"), remap = false)
+    private void lwjgl3ify$onClose(CallbackInfo ci) {
+        TextFieldHandler.endTextInput(null);
     }
 }


### PR DESCRIPTION
在使用 lwjgl3ify 时，我发现虽然聊天框可以正常使用中文输入法，但一些不使用标准的 GuiTextField 的界面（如告示牌编辑、书本编写以及 Xaero 小地图的路径点命名界面）无法唤醒 IME，导致无法输入中文。

这个 PR 通过为这些特定的 GUI 类添加 Mixin 钩子，在界面打开时显式调用 SDL_StartTextInput 来修复此问题。由于 lwjgl3ify 已经具备了将 SDL 文本事件注入键盘队列的逻辑，开启文本输入模式后，这些界面就能像聊天框一样正常接收中文字符了。

English Translation: I noticed that while the Chinese IME works fine in the chat box with lwjgl3ify, it fails to activate in screens that don't use the standard GuiTextField (such as sign editing, book writing, and Xaero's Minimap waypoint naming).

This PR fixes the issue by adding Mixin hooks for these specific GUI classes to explicitly call SDL_StartTextInput when they are opened. Since lwjgl3ify already has the logic to inject SDL text events into the keyboard queue, enabling the text input mode allows these screens to receive Chinese characters correctly, just like the chat box.