### PR TITLE
Fixed Scrolling on Ubuntu 

### DIFF
--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -7,7 +7,6 @@ import static org.lwjgl.sdl.SDLKeyboard.*;
 import static org.lwjgl.sdl.SDLKeycode.*;
 import static org.lwjgl.sdl.SDLMouse.*;
 import static org.lwjgl.sdl.SDLPixels.*;
-import static org.lwjgl.sdl.SDLTimer.SDL_GetTicksNS;
 import static org.lwjgl.sdl.SDLVideo.*;
 import static org.lwjgl.system.MemoryStack.*;
 import static org.lwjgl.system.MemoryUtil.*;

--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -1,14 +1,11 @@
 package org.lwjglx;
 
-import static org.lwjgl.sdl.SDLError.*;
 import static org.lwjgl.sdl.SDLEvents.*;
 import static org.lwjgl.sdl.SDLInit.*;
 import static org.lwjgl.sdl.SDLKeyboard.*;
 import static org.lwjgl.sdl.SDLKeycode.*;
 import static org.lwjgl.sdl.SDLMouse.*;
-import static org.lwjgl.sdl.SDLPixels.*;
 import static org.lwjgl.sdl.SDLVideo.*;
-import static org.lwjgl.system.MemoryStack.*;
 import static org.lwjgl.system.MemoryUtil.*;
 
 import org.lwjgl.sdl.SDL_Event;
@@ -49,7 +46,7 @@ public class Lwjgl3ifyEventLoop {
     public static final SDL_MouseButtonEvent mouseButtonEvent = event.button();
     public static final SDL_MouseWheelEvent mouseWheelEvent = event.wheel();
 
-    public static final boolean isWheelBugged = "x11".equals(SDL_GetCurrentVideoDriver());
+    public static final boolean isMouseWheelBugged = "x11".equals(SDL_GetCurrentVideoDriver());
 
     private static void internalPumpEvents() {
         if (!SDL_IsMainThread()) {
@@ -59,7 +56,6 @@ public class Lwjgl3ifyEventLoop {
         SDL_PumpEvents();
         int peepedEvents = 0;
         while ((peepedEvents = SDL_PeepEvents(eventPeepArray, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_LAST)) > 0) {
-            Lwjgl3ify.LOG.info("{} events logged", peepedEvents);
             for (int i = 0; i < peepedEvents; i++) {
                 memCopy(eventPeepArray.address(i), event.address(), event.sizeof());
                 if (Display.lwjgl3ify$handleSdlEvent()) {
@@ -97,7 +93,7 @@ public class Lwjgl3ifyEventLoop {
                         long wheelEventTimestamp = mouseWheelEvent.timestamp();
 
                         // duplicate scroll wheel inputs under certain circumstances, ignored when device ID mismatch
-                        if (isWheelBugged) {
+                        if (isMouseWheelBugged) {
                             if (lastWheelID != -1 && lastWheelID != mouseWheelEvent.which()) {
                                 lastWheelID = -1;
                                 continue;

--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -50,14 +50,17 @@ public class Lwjgl3ifyEventLoop {
     public static final SDL_MouseButtonEvent mouseButtonEvent = event.button();
     public static final SDL_MouseWheelEvent mouseWheelEvent = event.wheel();
 
+    public static final boolean isWheelBugged = "x11".equals(SDL_GetCurrentVideoDriver());
+
     private static void internalPumpEvents() {
         if (!SDL_IsMainThread()) {
             throw new IllegalStateException("SDL Event pump called from a non-main thread " + Thread.currentThread());
         }
-        long currentTimestamp = SDL_GetTicksNS();
+        int lastWheelID = -1;
         SDL_PumpEvents();
         int peepedEvents = 0;
         while ((peepedEvents = SDL_PeepEvents(eventPeepArray, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_LAST)) > 0) {
+            Lwjgl3ify.LOG.info("{} events logged", peepedEvents);
             for (int i = 0; i < peepedEvents; i++) {
                 memCopy(eventPeepArray.address(i), event.address(), event.sizeof());
                 if (Display.lwjgl3ify$handleSdlEvent()) {
@@ -94,16 +97,13 @@ public class Lwjgl3ifyEventLoop {
                     case SDL_EVENT_MOUSE_WHEEL -> {
                         long wheelEventTimestamp = mouseWheelEvent.timestamp();
 
-                        // duplicate scroll wheel inputs under certain circumstances, ignored when too recent
-                        if (wheelEventTimestamp > currentTimestamp) {
-                            if (Config.DEBUG_PRINT_MOUSE_EVENTS) {
-                                Lwjgl3ify.LOG.info("Skipped scroll wheel event at {}ns", wheelEventTimestamp);
+                        // duplicate scroll wheel inputs under certain circumstances, ignored when device ID mismatch
+                        if (isWheelBugged) {
+                            if (lastWheelID != -1 && lastWheelID != mouseWheelEvent.which()) {
+                                lastWheelID = -1;
+                                continue;
                             }
-                            break;
-                        } else {
-                            if (Config.DEBUG_PRINT_MOUSE_EVENTS) {
-                                Lwjgl3ify.LOG.info("Did not skip scroll wheel event at {}ns", wheelEventTimestamp);
-                            }
+                            lastWheelID = mouseWheelEvent.which();
                         }
 
                         float xoffset = mouseWheelEvent.x();

--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -12,7 +12,13 @@ import static org.lwjgl.sdl.SDLVideo.*;
 import static org.lwjgl.system.MemoryStack.*;
 import static org.lwjgl.system.MemoryUtil.*;
 
-import org.lwjgl.sdl.*;
+import org.lwjgl.sdl.SDL_Event;
+import org.lwjgl.sdl.SDL_KeyboardEvent;
+import org.lwjgl.sdl.SDL_MouseButtonEvent;
+import org.lwjgl.sdl.SDL_MouseMotionEvent;
+import org.lwjgl.sdl.SDL_MouseWheelEvent;
+import org.lwjgl.sdl.SDL_TextInputEvent;
+import org.lwjgl.sdl.SDL_WindowEvent;
 import org.lwjglx.input.KeyCodes;
 import org.lwjglx.input.Keyboard;
 import org.lwjglx.input.Mouse;

--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -90,8 +90,6 @@ public class Lwjgl3ifyEventLoop {
                             event.type() == SDL_EVENT_MOUSE_BUTTON_DOWN);
                     }
                     case SDL_EVENT_MOUSE_WHEEL -> {
-                        long wheelEventTimestamp = mouseWheelEvent.timestamp();
-
                         // duplicate scroll wheel inputs under certain circumstances, ignored when device ID mismatch
                         if (isMouseWheelBugged) {
                             if (lastWheelID != -1 && lastWheelID != mouseWheelEvent.which()) {

--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -7,17 +7,12 @@ import static org.lwjgl.sdl.SDLKeyboard.*;
 import static org.lwjgl.sdl.SDLKeycode.*;
 import static org.lwjgl.sdl.SDLMouse.*;
 import static org.lwjgl.sdl.SDLPixels.*;
+import static org.lwjgl.sdl.SDLTimer.SDL_GetTicksNS;
 import static org.lwjgl.sdl.SDLVideo.*;
 import static org.lwjgl.system.MemoryStack.*;
 import static org.lwjgl.system.MemoryUtil.*;
 
-import org.lwjgl.sdl.SDL_Event;
-import org.lwjgl.sdl.SDL_KeyboardEvent;
-import org.lwjgl.sdl.SDL_MouseButtonEvent;
-import org.lwjgl.sdl.SDL_MouseMotionEvent;
-import org.lwjgl.sdl.SDL_MouseWheelEvent;
-import org.lwjgl.sdl.SDL_TextInputEvent;
-import org.lwjgl.sdl.SDL_WindowEvent;
+import org.lwjgl.sdl.*;
 import org.lwjglx.input.KeyCodes;
 import org.lwjglx.input.Keyboard;
 import org.lwjglx.input.Mouse;
@@ -53,6 +48,7 @@ public class Lwjgl3ifyEventLoop {
         if (!SDL_IsMainThread()) {
             throw new IllegalStateException("SDL Event pump called from a non-main thread " + Thread.currentThread());
         }
+        long currentTimestamp = SDL_GetTicksNS();
         SDL_PumpEvents();
         int peepedEvents = 0;
         while ((peepedEvents = SDL_PeepEvents(eventPeepArray, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_LAST)) > 0) {
@@ -90,8 +86,23 @@ public class Lwjgl3ifyEventLoop {
                             event.type() == SDL_EVENT_MOUSE_BUTTON_DOWN);
                     }
                     case SDL_EVENT_MOUSE_WHEEL -> {
+                        long wheelEventTimestamp = mouseWheelEvent.timestamp();
+
+                        // duplicate scroll wheel inputs under certain circumstances, ignored when too recent
+                        if (wheelEventTimestamp > currentTimestamp) {
+                            if (Config.DEBUG_PRINT_MOUSE_EVENTS) {
+                                Lwjgl3ify.LOG.info("Skipped scroll wheel event at {}ns", wheelEventTimestamp);
+                            }
+                            break;
+                        } else {
+                            if (Config.DEBUG_PRINT_MOUSE_EVENTS) {
+                                Lwjgl3ify.LOG.info("Did not skip scroll wheel event at {}ns", wheelEventTimestamp);
+                            }
+                        }
+
                         float xoffset = mouseWheelEvent.x();
                         float yoffset = mouseWheelEvent.y();
+
                         Mouse
                             .addWheelEvent(yoffset == 0 ? (Config.INPUT_INVERT_X_WHEEL ? -xoffset : xoffset) : yoffset);
                     }


### PR DESCRIPTION
Fixes #328 
Noticed that there would be errant double scroll inputs, unless any mouse released happened more recently than any key press or mouse press. Apparently this is an issue with X11 and SDL, and happens on linux systems in Godot as well from what I read.
Whenever there was an errant wheel event, the wrong input seemed based on SDL nanosecond time, whereas the correct inputs seemed to be in milliseconds (maybe since system boot?).
Logging included with mouse event debug prints.
Would like to move the timestamp somewhere that is not always run with internalPumpEvents, but not sure where to put it, if there's a better way to compare, or if that matters.