### PR TITLE
Fix plugin errors when analyzing class files

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/oc/OcInputBuffer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/oc/OcInputBuffer.java
@@ -5,9 +5,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import li.cil.oc.client.gui.traits.InputBuffer$class;
-
-@Mixin(value = InputBuffer$class.class, remap = false)
+/// InputBuffer$class is public and could be specified directly, but doing so causes IDEA's linter to implode.
+/// TODO undo this whenever that bug is fixed
+@SuppressWarnings("UnusedMixin")
+@Mixin(remap = false, targets = {"li.cil.oc.client.gui.traits.InputBuffer$class"})
 public class OcInputBuffer {
 
     @Redirect(

--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/oc/OcInputBuffer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/oc/OcInputBuffer.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 /// InputBuffer$class is public and could be specified directly, but doing so causes IDEA's linter to implode.
 /// TODO undo this whenever that bug is fixed
 @SuppressWarnings("UnusedMixin")
-@Mixin(remap = false, targets = {"li.cil.oc.client.gui.traits.InputBuffer$class"})
+@Mixin(remap = false, targets = { "li.cil.oc.client.gui.traits.InputBuffer$class" })
 public class OcInputBuffer {
 
     @Redirect(


### PR DESCRIPTION
Something inside either IDEA itself or MCDev plugin implodes when processing this annotation; changing the target to be a string name instead of a direct reference fixes this.