### PR TITLE
Fix crash when sorting null launch class loader exclusions

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/Lwjgl3ify.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/Lwjgl3ify.java
@@ -3,6 +3,7 @@ package me.eigenraven.lwjgl3ify;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.Set;
 
 import net.minecraft.launchwrapper.Launch;
@@ -68,8 +69,10 @@ public class Lwjgl3ify {
             tfExclusionsF.setAccessible(true);
             @SuppressWarnings("unchecked")
             final Set<String> clExclusions = (Set<String>) clExclusionsF.get(loader);
+            clExclusions.removeIf(Objects::isNull);
             @SuppressWarnings("unchecked")
             final Set<String> tfExclusions = (Set<String>) tfExclusionsF.get(loader);
+            tfExclusions.removeIf(Objects::isNull);
             final ArrayList<String> clExclusionsSorted = new ArrayList<>(clExclusions);
             clExclusionsSorted.sort(Comparator.naturalOrder());
             final ArrayList<String> tfExclusionsSorted = new ArrayList<>(tfExclusions);


### PR DESCRIPTION
Fixes crash from null LaunchClassLoader exclusions

- Filters null entries from class loader and transformer exclusions before sorting
- Prevents `Comparator.naturalOrder()` from crashing when exclusions apparently contain null (sometimes?) 
- Fixes #236
  - https://github.com/Kai-Z-JP/KaizPatchX/issues/470
- Fixes #239
  - https://github.com/vfx-dev/SwanSong/issues/11