### PR TITLE
Add ScriptEngine redirect

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/redirects/ScriptEngineManager.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/redirects/ScriptEngineManager.java
@@ -1,0 +1,112 @@
+package me.eigenraven.lwjgl3ify.redirects;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.script.ScriptEngineFactory;
+
+public class ScriptEngineManager extends javax.script.ScriptEngineManager {
+
+    private static final String NASHORN_FACTORY_CLASS = "org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory";
+
+    public ScriptEngineManager() {
+        super(resolveClassLoader(null));
+        registerEmbeddedEngines();
+    }
+
+    public ScriptEngineManager(ClassLoader loader) {
+        super(resolveClassLoader(loader));
+        registerEmbeddedEngines();
+    }
+
+    private static ClassLoader resolveClassLoader(ClassLoader loader) {
+        if (loader != null) {
+            return loader;
+        }
+
+        ClassLoader contextLoader = Thread.currentThread()
+            .getContextClassLoader();
+        if (contextLoader != null) {
+            return contextLoader;
+        }
+
+        ClassLoader ownLoader = ScriptEngineManager.class.getClassLoader();
+        if (ownLoader != null) {
+            return ownLoader;
+        }
+
+        return ClassLoader.getSystemClassLoader();
+    }
+
+    private void registerEmbeddedEngines() {
+        if (hasJavaScriptEngineFactory()) {
+            return;
+        }
+
+        ScriptEngineFactory factory = createFactory(NASHORN_FACTORY_CLASS);
+        if (factory == null) {
+            return;
+        }
+
+        for (String name : factory.getNames()) {
+            registerEngineName(name, factory);
+        }
+        registerEngineName("JavaScript", factory);
+        registerEngineName("javascript", factory);
+        registerEngineName("js", factory);
+
+        for (String extension : factory.getExtensions()) {
+            registerEngineExtension(extension, factory);
+        }
+
+        for (String mimeType : factory.getMimeTypes()) {
+            registerEngineMimeType(mimeType, factory);
+        }
+    }
+
+    private boolean hasJavaScriptEngineFactory() {
+        for (ScriptEngineFactory factory : getEngineFactories()) {
+            for (String name : factory.getNames()) {
+                if ("JavaScript".equalsIgnoreCase(name) || "js".equalsIgnoreCase(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static ScriptEngineFactory createFactory(String factoryClassName) {
+        for (ClassLoader loader : candidateClassLoaders()) {
+            try {
+                Class<?> factoryClass = Class.forName(factoryClassName, true, loader);
+                return ScriptEngineFactory.class.cast(
+                    factoryClass.getDeclaredConstructor()
+                        .newInstance());
+            } catch (ClassNotFoundException ignored) {
+                // Try the next class loader.
+            } catch (ReflectiveOperationException | LinkageError | ClassCastException ignored) {
+                // ServiceLoader would ignore broken providers, so match that behavior here.
+            }
+        }
+
+        return null;
+    }
+
+    private static List<ClassLoader> candidateClassLoaders() {
+        List<ClassLoader> classLoaders = new ArrayList<>();
+        addClassLoader(
+            classLoaders,
+            Thread.currentThread()
+                .getContextClassLoader());
+        addClassLoader(classLoaders, ScriptEngineManager.class.getClassLoader());
+        addClassLoader(classLoaders, ClassLoader.getSystemClassLoader());
+        return classLoaders;
+    }
+
+    private static void addClassLoader(List<ClassLoader> classLoaders, ClassLoader classLoader) {
+        if (classLoader == null || classLoaders.contains(classLoader)) {
+            return;
+        }
+        classLoaders.add(classLoader);
+    }
+}

--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
@@ -33,9 +33,11 @@ public class LwjglRedirectTransformer extends Remapper implements RfbClassTransf
     private boolean transformed = false;
 
     final String[] fromPrefixes = new String[] { "org/lwjgl/", "javax/xml/bind/", "java/util/jar/Pack200",
-        "jdk/nashorn/", "com/mumfrey/liteloader/launch/ClassPathUtilities", "javax/activity/InvalidActivityException" };
+        "jdk/nashorn/", "javax/script/ScriptEngineManager", "com/mumfrey/liteloader/launch/ClassPathUtilities",
+        "javax/activity/InvalidActivityException" };
     final String[] toPrefixes = new String[] { "org/lwjglx/", "jakarta/xml/bind/",
         "me/eigenraven/lwjgl3ify/redirects/Pack200", "org/openjdk/nashorn/",
+        "me/eigenraven/lwjgl3ify/redirects/ScriptEngineManager",
         "me/eigenraven/lwjgl3ify/redirects/LiteLoaderClassPathUtilities",
         "me/eigenraven/lwjgl3ify/redirects/InvalidActivityException" };
 


### PR DESCRIPTION
The Lucky Blocks mod fails to parse data when launching the game.

I can confirm, that this PR fixes parsing issues related to Lucky Block addons.

To reproduce the issue, install the Lucky Blocks mod [1] and an addon [2].

This is likely the issue encountered in #235, but without any addons, as far as I can tell.

Disclosure: since I am unfamiliar with the codebase, I used an LLM during the creation of this PR.


[1] https://legacy.curseforge.com/minecraft/mc-mods/lucky-block/files/3652651
[2] https://legacy.curseforge.com/minecraft/customization/lucky-block-spiral-1-7-lucky-block-addon