### PR TITLE
Filter null exclusions after copying sets

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/Lwjgl3ify.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/Lwjgl3ify.java
@@ -69,13 +69,13 @@ public class Lwjgl3ify {
             tfExclusionsF.setAccessible(true);
             @SuppressWarnings("unchecked")
             final Set<String> clExclusions = (Set<String>) clExclusionsF.get(loader);
-            clExclusions.removeIf(Objects::isNull);
             @SuppressWarnings("unchecked")
             final Set<String> tfExclusions = (Set<String>) tfExclusionsF.get(loader);
-            tfExclusions.removeIf(Objects::isNull);
             final ArrayList<String> clExclusionsSorted = new ArrayList<>(clExclusions);
+            clExclusionsSorted.removeIf(Objects::isNull);
             clExclusionsSorted.sort(Comparator.naturalOrder());
             final ArrayList<String> tfExclusionsSorted = new ArrayList<>(tfExclusions);
+            tfExclusionsSorted.removeIf(Objects::isNull);
             tfExclusionsSorted.sort(Comparator.naturalOrder());
             for (String exclusion : clExclusionsSorted) {
                 LOG.info("LaunchClassLoader loader exclusion: {}", exclusion);


### PR DESCRIPTION
Follow-up to #336 

It seems possible for null entries to appear in the LaunchClassLoader exclusion sets between filtering the original sets and sorting the copied lists. The previous fix removed null entries from the original sets before copying them, but that did not fully cover this case. 

Sorry about that :/

<details>

<summary>crash log</summary>

```
java.lang.NullPointerException: Cannot invoke "java.lang.Comparable.compareTo(Object)" because "<parameter1>" is null
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Unknown Source)
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Unknown Source)
	at java.base/java.util.TimSort.binarySort(Unknown Source)
	at java.base/java.util.TimSort.sort(Unknown Source)
	at java.base/java.util.Arrays.sort(Unknown Source)
	at java.base/java.util.ArrayList.sortRange(Unknown Source)
	at java.base/java.util.ArrayList.sort(Unknown Source)
	at Launch//me.eigenraven.lwjgl3ify.Lwjgl3ify.postInit(Lwjgl3ify.java:77)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at Launch//cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at System//com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at System//com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at System//com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at System//com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at System//com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at Launch//cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
	at Launch//cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at System//com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at System//com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at System//com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at System//com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at System//com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at Launch//cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
	at Launch//cpw.mods.fml.common.Loader.initializeMods(Loader.java:742)
	at Launch//cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:311)
	at Launch//net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:552)
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878)
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
	at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47)
	at java.base/java.lang.Thread.run(Unknown Source)
```
</details>