### PR TITLE
Fix textBuffer keeping buffered text and bleeding it into the next input

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/client/TextFieldHandler.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/client/TextFieldHandler.java
@@ -47,6 +47,7 @@ public final class TextFieldHandler {
                 Lwjgl3ify.LOG.info("[DEBUG] Stopping text input");
             }
             MainThreadExec.runOnMainThread(() -> { SDL_StopTextInput(Display.getWindow()); });
+            textBuffer.setLength(0);
         }
         if (textField != null && textField == focusedTextInput.get()) {
             focusedTextInput = NULL_TEXT_FIELD;
@@ -62,6 +63,7 @@ public final class TextFieldHandler {
             textInputDepth = 0;
         }
         focusedTextInput = NULL_TEXT_FIELD;
+        textBuffer.setLength(0);
     }
 
     public static void setFocusedTextField(GuiTextField textField) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/lwjgl3ify/issues/342
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23831
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25195
@Sladki Narrowed it down in the issue, also made a good video of one the way to reproduce it

Tested in full pack and wasn't able to make it happen again. Didn't seem to cause side effects.