### PR TITLE
Add fence shims

### DIFF
--- a/src/generated/java/org/lwjglx/opengl/ARBSync.java
+++ b/src/generated/java/org/lwjglx/opengl/ARBSync.java
@@ -1,5 +1,8 @@
 package org.lwjglx.opengl;
 
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+
 public class ARBSync {
 
     public static final int GL_ALREADY_SIGNALED = (int) 37146;
@@ -22,4 +25,47 @@ public class ARBSync {
         return org.lwjgl.opengl.ARBSync.glGetInteger64(pname);
     }
 
+    public static org.lwjglx.opengl.GLSync glFenceSync(int condition, int flags) {
+        return new org.lwjglx.opengl.GLSync(org.lwjgl.opengl.ARBSync.glFenceSync(condition, flags));
+    }
+
+    public static boolean glIsSync(org.lwjglx.opengl.GLSync sync) {
+        return org.lwjgl.opengl.ARBSync.glIsSync(sync.getPointer());
+    }
+
+    public static void glDeleteSync(org.lwjglx.opengl.GLSync sync) {
+        org.lwjgl.opengl.ARBSync.glDeleteSync(sync.getPointer());
+    }
+
+    public static int glClientWaitSync(org.lwjglx.opengl.GLSync sync, int flags, long timeout) {
+        return org.lwjgl.opengl.ARBSync.glClientWaitSync(sync.getPointer(), flags, timeout);
+    }
+
+    public static void glWaitSync(org.lwjglx.opengl.GLSync sync, int flags, long timeout) {
+        org.lwjgl.opengl.ARBSync.glWaitSync(sync.getPointer(), flags, timeout);
+    }
+
+    public static void glGetInteger64(int pname, LongBuffer params) {
+        org.lwjgl.opengl.ARBSync.glGetInteger64v(pname, params);
+    }
+
+    public static void glGetSync(org.lwjglx.opengl.GLSync sync, int pname, IntBuffer length, IntBuffer values) {
+        org.lwjgl.opengl.ARBSync.glGetSynciv(sync.getPointer(), pname, length, values);
+    }
+
+    /**
+     * Overloads glGetSynciv.
+     * <p>
+     * 
+     * @deprecated Will be removed in 3.0. Use {@link #glGetSynci} instead.
+     */
+    @Deprecated
+    public static int glGetSync(org.lwjglx.opengl.GLSync sync, int pname) {
+        return org.lwjgl.opengl.ARBSync.glGetSynci(sync.getPointer(), pname, null);
+    }
+
+    /** Overloads glGetSynciv. */
+    public static int glGetSynci(org.lwjglx.opengl.GLSync sync, int pname) {
+        return org.lwjgl.opengl.ARBSync.glGetSynci(sync.getPointer(), pname, null);
+    }
 }

--- a/src/generated/java/org/lwjglx/opengl/GL32.java
+++ b/src/generated/java/org/lwjglx/opengl/GL32.java
@@ -1,5 +1,7 @@
 package org.lwjglx.opengl;
 
+import java.nio.IntBuffer;
+
 public class GL32 {
 
     public static final int GL_ALREADY_SIGNALED = (int) 37146;
@@ -182,4 +184,39 @@ public class GL32 {
             .glTexImage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations);
     }
 
+    public static boolean glIsSync(org.lwjglx.opengl.GLSync sync) {
+        return org.lwjgl.opengl.GL32.glIsSync(sync.getPointer());
+    }
+
+    public static void glDeleteSync(org.lwjglx.opengl.GLSync sync) {
+        org.lwjgl.opengl.GL32.glDeleteSync(sync.getPointer());
+    }
+
+    public static int glClientWaitSync(org.lwjglx.opengl.GLSync sync, int flags, long timeout) {
+        return org.lwjgl.opengl.GL32.glClientWaitSync(sync.getPointer(), flags, timeout);
+    }
+
+    public static void glWaitSync(org.lwjglx.opengl.GLSync sync, int flags, long timeout) {
+        org.lwjgl.opengl.GL32.glWaitSync(sync.getPointer(), flags, timeout);
+    }
+
+    public static void glGetSync(org.lwjglx.opengl.GLSync sync, int pname, IntBuffer length, IntBuffer values) {
+        org.lwjgl.opengl.GL32.glGetSynciv(sync.getPointer(), pname, length, values);
+    }
+
+    /**
+     * Overloads glGetSynciv.
+     * <p>
+     * 
+     * @deprecated Will be removed in 3.0. Use {@link #glGetSynci} instead.
+     */
+    @Deprecated
+    public static int glGetSync(org.lwjglx.opengl.GLSync sync, int pname) {
+        return org.lwjgl.opengl.GL32.glGetSynci(sync.getPointer(), pname, null);
+    }
+
+    /** Overloads glGetSynciv. */
+    public static int glGetSynci(org.lwjglx.opengl.GLSync sync, int pname) {
+        return org.lwjgl.opengl.GL32.glGetSynci(sync.getPointer(), pname, null);
+    }
 }


### PR DESCRIPTION
## Summary
This implements the shims for various GLSync methods. Previously, calling these methods would result in a NoSuchMethodException as they were redirected but not implemented.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
