### PR TITLE
Avoid filling the stack trace in Lwjgl3AwareException

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
@@ -130,6 +130,7 @@ public class LwjglRedirectTransformer extends Remapper implements RfbClassTransf
     }
 
     public static class Lwjgl3AwareException extends RuntimeException {
+
         Lwjgl3AwareException() {
             super(null, null, false, false);
         }

--- a/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/rfb/transformers/LwjglRedirectTransformer.java
@@ -130,6 +130,9 @@ public class LwjglRedirectTransformer extends Remapper implements RfbClassTransf
     }
 
     public static class Lwjgl3AwareException extends RuntimeException {
+        Lwjgl3AwareException() {
+            super(null, null, false, false);
+        }
     }
 
     public class EscapingClassRemapper extends ClassRemapper {


### PR DESCRIPTION
Since the exception is only ever used to change the control flow and is always ignored there is no need to calculate the stack trace, which should improve launch performance (it's quite a slow operation). I haven't benchmarked it since its a trivial optimization.

Side note, why is it even public? Are mods expected to use it?

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge