### PR TITLE
Fix occasional black screen on startup caused by stale/zero framebuffer size

### DIFF
--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -95,8 +95,6 @@ public class Display {
     private static int displayFramebufferHeight = 1;
 
     private static boolean latestResized = false;
-    private static int latestWidth = 0;
-    private static int latestHeight = 0;
     private static boolean cancelNextChar = false;
     private static Keyboard.KeyEvent ingredientKeyEvent;
     private static ByteBuffer[] savedIcons;
@@ -441,8 +439,6 @@ public class Display {
         if (displayFramebufferWidth != width || displayFramebufferHeight != height) {
             displayFramebufferWidth = width;
             displayFramebufferHeight = height;
-            latestWidth = width;
-            latestHeight = height;
             latestResized |= markResize;
         }
     }
@@ -869,8 +865,6 @@ public class Display {
                 if (Lwjgl3ifyEventLoop.windowEvent.windowID() != sdlWindowId) {
                     yield true;
                 }
-                displayWidth = Lwjgl3ifyEventLoop.windowEvent.data1();
-                displayHeight = Lwjgl3ifyEventLoop.windowEvent.data2();
                 updateWindowSizeFromSdl(true);
                 if (Config.DEBUG_PRINT_WINDOW_EVENTS) {
                     Lwjgl3ify.LOG.info(
@@ -893,8 +887,8 @@ public class Display {
                     Lwjgl3ify.LOG.info(
                         "[DEBUG-WINDOW] framebuffer-pixel scale change window:{} w:{} h:{}",
                         Lwjgl3ifyEventLoop.windowEvent.windowID(),
-                        displayFramebufferWidth,
-                        displayFramebufferHeight);
+                        Lwjgl3ifyEventLoop.windowEvent.data1(),
+                        Lwjgl3ifyEventLoop.windowEvent.data2());
                 }
                 yield true;
             }

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -313,18 +313,7 @@ public class Display {
             displayFocused = (actualWindowFlags & SDL_WINDOW_INPUT_FOCUS) != 0;
             displayVisible = (actualWindowFlags & SDL_WINDOW_MINIMIZED) == 0;
 
-            try (MemoryStack stack = stackPush()) {
-                IntBuffer w = stack.ints(0);
-                IntBuffer h = stack.ints(0);
-                SDL_GetWindowSize(sdlWindow, w, h);
-                displayWidth = w.get(0);
-                displayHeight = h.get(0);
-                SDL_GetWindowSizeInPixels(sdlWindow, w, h);
-                displayFramebufferWidth = w.get(0);
-                latestWidth = displayFramebufferWidth;
-                displayFramebufferHeight = h.get(0);
-                latestHeight = displayFramebufferHeight;
-            }
+            updateWindowSizeFromSdl(false);
 
             if (savedIcons != null) {
                 setIcon(savedIcons);
@@ -430,6 +419,32 @@ public class Display {
         Lwjgl3ifyEventLoop.pumpEvents();
         Keyboard.poll();
         Mouse.poll();
+    }
+
+    private static void updateWindowSizeFromSdl(boolean markResize) {
+        try (MemoryStack stack = stackPush()) {
+            IntBuffer w = stack.ints(0);
+            IntBuffer h = stack.ints(0);
+            SDL_GetWindowSize(sdlWindow, w, h);
+            displayWidth = w.get(0);
+            displayHeight = h.get(0);
+            SDL_GetWindowSizeInPixels(sdlWindow, w, h);
+            updateFramebufferSize(w.get(0), h.get(0), markResize);
+        }
+    }
+
+    private static void updateFramebufferSize(int width, int height, boolean markResize) {
+        if (width <= 0 || height <= 0) {
+            return;
+        }
+
+        if (displayFramebufferWidth != width || displayFramebufferHeight != height) {
+            displayFramebufferWidth = width;
+            displayFramebufferHeight = height;
+            latestWidth = width;
+            latestHeight = height;
+            latestResized |= markResize;
+        }
     }
 
     public static void swapBuffers() {
@@ -805,6 +820,7 @@ public class Display {
                 if (Lwjgl3ifyEventLoop.windowEvent.windowID() != sdlWindowId) {
                     yield true;
                 }
+                updateWindowSizeFromSdl(true);
                 displayDirty = true;
                 yield true;
             }
@@ -842,6 +858,7 @@ public class Display {
                 if (Lwjgl3ifyEventLoop.windowEvent.windowID() != sdlWindowId) {
                     yield true;
                 }
+                updateWindowSizeFromSdl(true);
                 displayVisible = true;
                 if (Config.DEBUG_PRINT_WINDOW_EVENTS) {
                     Lwjgl3ify.LOG.info("[DEBUG-WINDOW] window-restore");
@@ -854,6 +871,7 @@ public class Display {
                 }
                 displayWidth = Lwjgl3ifyEventLoop.windowEvent.data1();
                 displayHeight = Lwjgl3ifyEventLoop.windowEvent.data2();
+                updateWindowSizeFromSdl(true);
                 if (Config.DEBUG_PRINT_WINDOW_EVENTS) {
                     Lwjgl3ify.LOG.info(
                         "[DEBUG-WINDOW] window-resize window:{} w:{} h:{}",
@@ -867,8 +885,10 @@ public class Display {
                 if (Lwjgl3ifyEventLoop.windowEvent.windowID() != sdlWindowId) {
                     yield true;
                 }
-                displayFramebufferWidth = Lwjgl3ifyEventLoop.windowEvent.data1();
-                displayFramebufferHeight = Lwjgl3ifyEventLoop.windowEvent.data2();
+                updateFramebufferSize(
+                    Lwjgl3ifyEventLoop.windowEvent.data1(),
+                    Lwjgl3ifyEventLoop.windowEvent.data2(),
+                    true);
                 if (Config.DEBUG_PRINT_WINDOW_EVENTS) {
                     Lwjgl3ify.LOG.info(
                         "[DEBUG-WINDOW] framebuffer-pixel scale change window:{} w:{} h:{}",
@@ -876,9 +896,6 @@ public class Display {
                         displayFramebufferWidth,
                         displayFramebufferHeight);
                 }
-                latestResized = true;
-                latestWidth = displayFramebufferWidth;
-                latestHeight = displayFramebufferHeight;
                 yield true;
             }
             case SDL_EVENT_WINDOW_MOVED -> {


### PR DESCRIPTION
## Summary

During client startup I quite often get a black screen instead of the game starting to load. Then only issue is to force restart because it will then never start rendering.

Since I usually tab to something else after pressing Launch in prism the biggest suspect right now is framebuffer size at context creation being 0x0.

This try to fix this by centralising window/framebuffer size tracking, and ignoring non positive sizes.

Been trying to launch full pack almost in a loop for the last 2h and didn't get it to happen again. Kinda want to have faith this time because I've been trying to get to the bottom of this one for way too long.


## Checklist
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md
