### PR TITLE
Fix relauncher

### DIFF
--- a/launcher-metadata/version.json
+++ b/launcher-metadata/version.json
@@ -623,8 +623,8 @@
         {
             "downloads": {
                 "artifact": {
-                    "sha1": "",
-                    "size": 0,
+                    "sha1": "521616dc7487b42bef0e803bd2fa3faf668101d7",
+                    "size": 5762,
                     "url": "https://libraries.minecraft.net/lzma/lzma/0.0.1/lzma-0.0.1.jar"
                 }
             },

--- a/prism-libraries/patches/net.minecraftforge.json
+++ b/prism-libraries/patches/net.minecraftforge.json
@@ -127,8 +127,8 @@
         {
             "downloads": {
                 "artifact": {
-                    "sha1": "",
-                    "size": 0,
+                    "sha1": "521616dc7487b42bef0e803bd2fa3faf668101d7",
+                    "size": 5762,
                     "url": "https://libraries.minecraft.net/lzma/lzma/0.0.1/lzma-0.0.1.jar"
                 }
             },

--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Downloader.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/Downloader.java
@@ -384,6 +384,8 @@ public class Downloader {
                         String httpErr = "<could not read error response>";
                         try (InputStream errorStream = conn.getErrorStream()) {
                             IOUtils.toString(errorStream, StandardCharsets.UTF_8);
+                        } catch (Exception e2) {
+                            e.addSuppressed(e2);
                         } finally {
                             System.err.printf(
                                 "Received HTTP error code when reading %s: %d: %s \n%s\n",


### PR DESCRIPTION
## Summary

- Downloader.java was suppressing the exception coming from the main download if `getErrorStream()` returned null (happens on a checksum mismatch)
- lzma-0.0.1.jar had a missing hash+size and the relauncher failed if it was not in the cache already.

Resolves https://github.com/GTNewHorizons/lwjgl3ify/issues/338

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
