### PR TITLE
Add version information for embedded ASM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -195,6 +195,11 @@ val forgePatchesJar = tasks.register<Jar>("forgePatchesJar") {
                 "Main-Class" to "me.eigenraven.lwjgl3ify.rfb.entry.ServerMain"
             )
         )
+
+        attributes(
+            mapOf("Implementation-Version" to libs.asm.get().version),
+            "org/objectweb/asm/"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
By default, Mixin detects the minor version of the loaded ASM library by checking the package version. I have no idea how this works with UniMixins - possibly because it shades ASM itself. However, if using the non-shaded ASM, Mixin relies on the package's implementation version, which gets picked up as the version of the forgePatches jar.

This PR adds ASM's version to the manifest, so Mixin can read it.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
