### PR TITLE
Fix lost scroll notches on high-resolution mouse wheels

### DIFF
--- a/src/main/java/org/lwjglx/input/Mouse.java
+++ b/src/main/java/org/lwjglx/input/Mouse.java
@@ -165,10 +165,12 @@ public class Mouse {
             delta = Math.signum(delta);
         }
 
-        final int lastWheel = (int) fractionalWheelPosition;
+        // Round instead of truncating toward zero, otherwise the first notch after a direction change is lost
+        // when hi-res sub-steps don't sum to exactly one notch (e.g. Logitech MagSpeed wheels)
+        final int lastWheel = (int) Math.round(fractionalWheelPosition);
         fractionalWheelPosition += delta;
         totalScrollAmount += delta;
-        final int newWheel = (int) fractionalWheelPosition;
+        final int newWheel = (int) Math.round(fractionalWheelPosition);
         if (newWheel != lastWheel) {
             lastxEvents[queue.getNextPos()] = lastEventX;
             lastyEvents[queue.getNextPos()] = lastEventY;
@@ -188,7 +190,7 @@ public class Mouse {
 
             queue.add();
         }
-        fractionalWheelPosition = fractionalWheelPosition % 1;
+        fractionalWheelPosition -= newWheel;
     }
 
     public static void poll() {


### PR DESCRIPTION
## Summary
Fixes an issue where scroll wheel inputs (like switching hotbar slots) sometimes get ignored, especially when changing the scroll direction on a mouse with high-resolution scrolling (in my case a Logitech MX Master 3S).

The old code tracks the scroll steps by adding up fractional movements and casting the total to an integer, but the casting truncates to zero and therefor creates a "dead zone" around zero that can be up to two notches wide.
Enabling `forceDiscreteScrolling` made it even worse and lead to jumping of 4-5 slots at a time.

So instead of truncating toward zero, we now round the accumulator to the nearest integer notch and keep the remainder within -0.5 and 0.5.
This should then match the standard Linux kernel behavior and a mouse without high-res scrolling does normal +/- 1 steps, so this should be unaffected to them.

Tested in GTNH 2.9.0-beta2 on Linux (Hyprland, SDL3 Wayland) with Logitech MX Master 3S. Every physical notch now reliably triggers a scroll event in both directions.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
