### PR TITLE
Fix: Can't auto-approve the relaunch when hideSettingsOnLauncher == true

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/relauncher/RelauncherUserInterface.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/relauncher/RelauncherUserInterface.java
@@ -181,7 +181,11 @@ public class RelauncherUserInterface {
 
     public void startSettingsIfNeeded() {
         if (RelauncherConfig.config.hideSettingsOnLaunch) {
+            // The settings GUI is skipped, so nobody will ever click the "Run" button.
+            // Approve the relaunch with the saved config here, otherwise Relauncher.run()
+            // sees runClicked == false and silently exits without starting the game.
             // TODO: Show a countdown and add a way to show settings again
+            runClicked = true;
             return;
         }
         invokeOnSwingThread(true, () -> {


### PR DESCRIPTION
## Issue
startSettingsIfNeeded() returns early when lwjgl3ify-relauncher.json:hideSettingsOnLaunch == true, but runClicked was only ever set by the lwjgl3ify relauncher settings's Run button. Relauncher.run() then sees runClicked == false and exits the JVM silently, so the game never launches and no window ever appears.

## Summary
Set runClicked = true in the hidden-settings branch so the saved config is applied and the relaunch proceeds, which is what enabling the option implies.

> rename download lib and full test in GTNH2.9.0beta2 only

## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
