### PR TITLE
Fix LWJGL2 scancode conversion in input events

### DIFF
--- a/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
+++ b/src/main/java/org/lwjglx/Lwjgl3ifyEventLoop.java
@@ -130,7 +130,7 @@ public class Lwjgl3ifyEventLoop {
         final long keyNamePtr = nSDL_GetKeyName(keyCode);
         final int rawKeyCode = SDL_GetKeyFromScancode(scanCode, kmods, false);
         final int lwjgl2KeyCode = KeyCodes.sdlKeycodeToLwjgl(keyCode);
-        final int lwjgl2ScanCode = KeyCodes.sdlScancodeToLwjgl(keyCode);
+        final int lwjgl2ScanCode = KeyCodes.sdlScancodeToLwjgl(scanCode);
 
         if (Config.DEBUG_PRINT_KEY_EVENTS) {
             Lwjgl3ify.LOG.info(


### PR DESCRIPTION
## Summary
lwjgl2ScanCode in Lwjgl3ifyEventLoop is made using a KeyCode instead of a ScanCode.

I have not yet tested this but it should work fine.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
