### PR TITLE
Fix OpenAL ignoring the requested output device

### DIFF
--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -4,7 +4,6 @@ import static org.lwjgl.system.MemoryStack.stackPush;
 
 import java.nio.IntBuffer;
 
-import org.lwjgl.openal.ALC10;
 import org.lwjgl.openal.ALCCapabilities;
 import org.lwjgl.system.MemoryStack;
 import org.lwjglx.LWJGLException;
@@ -63,9 +62,7 @@ public class AL {
             attribs.put(0);
             attribs.flip();
 
-            String defaultDevice = org.lwjgl.openal.ALC10.alcGetString(0, ALC10.ALC_DEFAULT_DEVICE_SPECIFIER);
-
-            long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(defaultDevice);
+            long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(deviceArguments);
 
             if (deviceHandle == 0) {
                 throw new LWJGLException("Could not open ALC device");

--- a/src/main/java/org/lwjglx/openal/AL.java
+++ b/src/main/java/org/lwjglx/openal/AL.java
@@ -65,7 +65,8 @@ public class AL {
             long deviceHandle = org.lwjgl.openal.ALC10.alcOpenDevice(deviceArguments);
 
             if (deviceHandle == 0) {
-                throw new LWJGLException("Could not open ALC device");
+                throw new LWJGLException(
+                    "Could not open ALC device: " + (deviceArguments == null ? "default" : deviceArguments));
             }
 
             alcDevice = new ALCdevice(deviceHandle);


### PR DESCRIPTION
## Summary
Pass the requested device name to alcOpenDevice instead of ignoring it and forcing default output.

This should also allow us to add an output device selector from Hodgepodge side.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)