### PR TITLE
fix hang on context destroy

### DIFF
--- a/src/main/java/org/lwjglx/opengl/ContextGL.java
+++ b/src/main/java/org/lwjglx/opengl/ContextGL.java
@@ -23,6 +23,8 @@ import org.lwjgl.sdl.SDLVideo;
 import org.lwjglx.PointerBuffer;
 import org.lwjglx.Sys;
 
+import me.eigenraven.lwjgl3ify.client.MainThreadExec;
+
 /**
  * <p/>
  * Context encapsulates an OpenGL context.
@@ -91,12 +93,14 @@ public final class ContextGL implements Context {
 
     public synchronized void destroy() {
         if (shared && sdlWindow != NULL) {
-            if (sdlContext != NULL) {
-                SDLVideo.SDL_GL_DestroyContext(sdlContext);
-                sdlContext = NULL;
-            }
-            SDLVideo.SDL_DestroyWindow(sdlWindow);
-            sdlWindow = NULL;
+            MainThreadExec.runOnMainThread(() -> {
+                if (sdlContext != NULL) {
+                    SDLVideo.SDL_GL_DestroyContext(sdlContext);
+                    sdlContext = NULL;
+                }
+                SDLVideo.SDL_DestroyWindow(sdlWindow);
+                sdlWindow = NULL;
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

In GTNewHorizons/BetterLoadingScreen/pull/45 ([commit](https://github.com/GTNewHorizons/BetterLoadingScreen/pull/45/changes/25dbbb68e1eb681ff52a207b2a94e77d57410c16)) we now destroy the splash screen context on client thread, which causes hang on macos right before getting to the main menu

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
